### PR TITLE
docs: add live demo section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # reading-notes (Backend API)
 
-読書中の **引用（quote）/メモ（memo）** を **安全に保存・検索** できる Rails API。
+読書中の引用・メモを **安全に保存し、後から高速に検索できる**  
+**信頼性重視のRailsバックエンドAPI**。
 **DB制約・一貫したエラーレスポンス・トランザクション整合性** を重視して実装。
 
 ## What this is
@@ -13,6 +14,9 @@
 
 - Ruby 3.2.2 / Rails 8.0.4 (API mode)
 - PostgreSQL 16
+- Fly.io（production hosting）
+- Neon（serverless PostgreSQL）
+- Docker（reproducible runtime）
 - RSpec（`64 examples, 0 failures`）
 
 ## Design highlights (why it’s “safe”)
@@ -51,12 +55,20 @@ API contract (SSOT): `backend/docs/40_api/api_overview.md`
 
 ## Live Demo
 
-- API Base URL: https://xxxxx.fly.dev
+- このバックエンドは **API専用サーバー** です。ブラウザのトップページ（`/`）には画面は表示されません。
+
+### Health check
+https://backend-withered-voice-4962.fly.dev/healthz
+- → `{ "ok": true }` が返れば本番稼働中です。
+
+### Books API
+https://backend-withered-voice-4962.fly.dev/api/books
+
 
 ### Quick smoke test
 
 ```bash
-curl -i https://xxxxx.fly.dev/api/books
+curl -i https://backend-withered-voice-4962.fly.dev/api/books
 ```
 
 **本プロジェクトは、機能の多さよりもデータ整合性を優先し、小さくても信頼できるバックエンドAPIの実現を目的として設計しました。**


### PR DESCRIPTION
## 概要（Summary）
Fly.io にデプロイ済みの API にすぐアクセスできるよう、README に Live Demo セクションを追加しました。

## 背景（Background）
バックエンド API は現在、本番環境（Fly.io + Neon）で稼働しています。  
デプロイ済みエンドポイントを明示することで、レビューのしやすさとポートフォリオの明確さを向上させます。

## 変更内容（Changes）
- README に Live Demo セクションを追加
- Health check エンドポイントを明示
- Books API への直接アクセス URL を記載
- curl による簡易スモークテスト例を追加

## 影響範囲（Impact）
- 実行時の挙動への影響なし（ドキュメント変更のみ）
- API の検証容易性・レビュー効率・ポートフォリオ可読性を向上