### PR TITLE
chore: add fly.toml to track Fly deployment config

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,27 @@
+# fly.toml app configuration file generated for backend-withered-voice-4962 on 2026-02-12T10:46:44+09:00
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
+
+app = 'backend-withered-voice-4962'
+primary_region = 'syd'
+console_command = '/rails/bin/rails console'
+
+[env]
+  PORT = '8080'
+
+[processes]
+  app = 'bin/rails server -b 0.0.0.0 -p 8080'
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = 'stop'
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ['app']
+
+[[vm]]
+  memory = '1gb'
+  cpus = 1
+  memory_mb = 1024


### PR DESCRIPTION
## 概要
- Fly.io アプリ設定をバージョン管理するため、`fly.toml` をリポジトリに追加。

## 目的
- `fly.toml` が存在せず `fly status` が失敗していたため。
- アプリ名・リージョン・プロセス・ポート設定を Git 管理し、環境再現性を確保するため。

## 影響範囲 / リスク
- 設定ファイル追加のみで、実行時の挙動は変化しない。
- 本番環境への反映は `fly deploy` 実行時のみ。

## デプロイ方法
- 手動反映:
  - `fly deploy -a backend-withered-voice-4962`

## 補足
- App: `backend-withered-voice-4962`
- Region: `syd`
- Internal port: `8080`