### PR TITLE
feat: add root endpoint returning API status JSON

### DIFF
--- a/backend/app/controllers/health_controller.rb
+++ b/backend/app/controllers/health_controller.rb
@@ -1,5 +1,7 @@
-class HealthController < ActionController::API
-  def show
-    render json: { ok: true }
-  end
+def root
+  render json: {
+    service: "Reading Notes Backend API",
+    status: "ok",
+    health: "/healthz"
+  }
 end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+   root to: "health#root"
    get "/healthz", to: "health#show"
 
   namespace :api do


### PR DESCRIPTION
本PRでは、Base URLアクセス時にAPIの状態が確認できるよう、rootエンドポイントを追加しました。

これにより、ブラウザまたはcurlでBase URLにアクセスした際に、APIサービスの稼働状況およびヘルスチェックエンドポイントの場所を即座に確認できるようになります。

従来は /healthz のみが稼働確認用エンドポイントでしたが、本変更により Base URL (/) からもAPIサービスの存在が明確になります。

特に第三者によるポートフォリオ評価時において、
	•	Base URLアクセス時にAPIサービスであることが明確に分かる
	•	稼働確認方法がすぐに分かる
	•	API専用アプリケーションとしての構成が理解しやすくなることを目的としています。
