### PR TITLE
fix: make DATABASE_URL optional locally and remove strict requirement…fix: stabilize DATABASE_URL handling and restore production-safe configuration

### DIFF
--- a/backend/app/controllers/health_controller.rb
+++ b/backend/app/controllers/health_controller.rb
@@ -1,7 +1,15 @@
-def root
-  render json: {
-    service: "Reading Notes Backend API",
-    status: "ok",
-    health: "/healthz"
-  }
+# frozen_string_literal: true
+
+class HealthController < ActionController::API
+  def show
+    render json: { ok: true }
+  end
+
+  def root
+    render json: {
+      service: "Reading Notes Backend API",
+      status: "ok",
+      health: "/healthz"
+    }
+  end
 end

--- a/backend/config/database.yml
+++ b/backend/config/database.yml
@@ -22,7 +22,7 @@ default: &default
 
 development:
   <<: *default
-  url: <%= ENV.fetch("DATABASE_URL") %>
+  url: <%= ENV["DATABASE_URL"] || "postgres://postgres:postgres@localhost:5432/postgres" %>
 
   # The specified database role being used to connect to PostgreSQL.
   # To create additional roles in PostgreSQL see `$ createuser --help`.
@@ -56,7 +56,7 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  url: <%= ENV.fetch("DATABASE_URL_TEST") { ENV.fetch("DATABASE_URL") } %>
+  url: <%= ENV["DATABASE_URL_TEST"] || ENV["DATABASE_URL"] || "postgres://postgres:postgres@localhost:5432/postgres" %>
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is
@@ -81,7 +81,7 @@ test:
 production:
   primary: &primary_production
     <<: *default
-    url: <%= ENV.fetch("DATABASE_URL") %>
+    url: <%= ENV["DATABASE_URL"] %>
 
   cache:
     <<: *primary_production

--- a/backend/config/initializers/require_database_url.rb
+++ b/backend/config/initializers/require_database_url.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+if Rails.env.production? && ENV["DATABASE_URL"].to_s.empty?
+  raise "DATABASE_URL is required in production"
+end


### PR DESCRIPTION
DATABASE_URL の扱いを見直し、ローカル開発環境と本番環境の両方で安定して起動できるよう修正しました。

変更内容:

■ HealthController の修正
- root エンドポイントがクラス外に定義されていた問題を修正
- HealthController クラス内に root アクションを正式に実装
- / および /healthz の両エンドポイントが安定して動作するよう整理

■ database.yml の修正
- development / test 環境で DATABASE_URL 未設定時のフォールバックURLを追加
- ENV.fetch("DATABASE_URL") を廃止し ENV["DATABASE_URL"] ベースに変更
- zeitwerk:check やローカル環境での起動失敗を防止

development:
  DATABASE_URL 未設定時:
  postgres://postgres:postgres@localhost:5432/postgres

test:
  DATABASE_URL_TEST → DATABASE_URL → ローカルDB の順で解決

production:
  DATABASE_URL 必須の構成を維持

■ production安全対策の追加
- config/initializers/require_database_url.rb を追加
- production環境で DATABASE_URL 未設定の場合は起動時に例外を発生させる
- 本番環境の設定ミスによる silent failure を防止

目的:

- ローカル開発環境の再現性向上
- Docker / ローカル / Fly.io 本番環境の整合性確保
- DATABASE_URL 未設定による起動失敗の防止
- 本番環境の安全性確保

これにより環境差異による起動トラブルを防ぎ、安定したデプロイが可能になりました。