### PR TITLE
Update README with authentication flow and API usage

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,7 +1,7 @@
 # Reading Notes Backend
 
-データ整合性と障害耐性を重視して設計した
-読書引用管理用 REST API。
+データ整合性と障害耐性を重視して設計した読書引用管理用 REST API。
+Bearer トークン認証と所有者ベースのデータアクセス制御を実装している。
 
 
 ## Production URL
@@ -12,24 +12,28 @@ https://backend-withered-voice-4962.fly.dev
 Example:
 
 ```bash
-curl https://backend-withered-voice-4962.fly.dev/api/books
-
+curl https://backend-withered-voice-4962.fly.dev/healthz
 ```
+
 ## Design Intent
 
 本APIは以下を重視して設計した。
 
 - **DB制約によるデータ整合性の保証**
-  - NOT NULL（books.title, notes.page 等） / CHECK / FK を用いてアプリ層の不具合でも破壊的データを防ぐ
+  - NOT NULL / CHECK / FK を用いてアプリ層の不具合でも破壊的データを防ぐ
 - **例外系の統一**
-  - 400 / 404 / 422 / 500 を ApplicationController で一元処理
-  - DB制約違反（NotNullViolation, InvalidForeignKey, RecordNotUnique, CheckViolation）は 422 に変換
+  - 400 / 401 / 404 / 422 / 500 を ApplicationController で一元処理
+  - DB制約違反（NotNullViolation, InvalidForeignKey, CheckViolation）は 422 に変換
+  - レスポンス形式 `{ error: { code, message, details? } }` に統一
+- **Bearer トークン認証と所有者スコープ**
+  - ログイン時に発行した raw トークンは返却のみとし、DBには SHA256 digest のみ保存
+  - 全データエンドポイントで `current_user.books` による所有者フィルタリングを実施
 - **無料サーバーレス構成での実運用再現**
   - Fly.io + Neon による公開環境
   - コールドスタート遅延を含めて説明可能な状態
 
-目的は  
-**「壊れないAPIを設計・説明できることの証明」**  
+目的は
+**「壊れないAPIを設計・説明できることの証明」**
 である。
 
 ## 技術スタック
@@ -46,35 +50,51 @@ curl https://backend-withered-voice-4962.fly.dev/api/books
 ### ER 図
 
 ```
-┌─────────────┐       ┌─────────────┐
-│    books    │       │    notes    │
-├─────────────┤       ├─────────────┤
-│ id          │◄──────│ book_id(FK) │
-│ title       │  1:N  │ id          │
-│ author      │       │ page        │
-│ deleted_at  │       │ quote       │
-│ created_at  │       │ memo        │
-│ updated_at  │       │ created_at  │
-└─────────────┘       │ updated_at  │
-                      └─────────────┘
+┌──────────┐  1:N  ┌──────────┐  1:N  ┌──────────┐
+│  users   ├───────┤  books   ├───────┤  notes   │
+├──────────┤       ├──────────┤       ├──────────┤
+│ id       │       │ id       │       │ id       │
+│ email    │       │ user_id  │       │ book_id  │
+│ password │       │ title    │       │ page     │
+│  _digest │       │ author   │       │ quote    │
+└────┬─────┘       │ deleted_at       │ memo     │
+     │ 1:N         └──────────┘       └──────────┘
+     ▼
+┌──────────────────┐
+│  access_tokens   │
+├──────────────────┤
+│ id               │
+│ user_id          │
+│ token_digest     │
+│ expires_at       │
+│ revoked_at       │
+│ last_used_at     │
+└──────────────────┘
 ```
 
 ### 主な設計ポイント
 
-- **論理削除**: Book は `deleted_at` による論理削除（Note との参照整合性を保ち、履歴を失わないため）
-- **FK 制約**: `notes.book_id → books.id` は `ON DELETE RESTRICT`（Note が存在する Book の誤削除を防ぐため）
-- **CHECK 制約**: `quote` 最大1000文字、`memo` 最大2000文字（アプリのバグや不正入力があってもDBで破壊的データを防ぐため）
+- **所有者ベースのアクセス**: Book は必ず User に属し、API は `current_user.books` 経由でのみアクセスできる。他ユーザーのデータは参照・操作不可
+- **論理削除**: Book は `deleted_at` による論理削除。Note との参照整合性を保ち、履歴を失わないため
+- **FK 制約（RESTRICT）**: `notes.book_id → books.id` は `ON DELETE RESTRICT`。Note が存在する Book の誤削除を DB レベルで防ぐ
+- **CHECK 制約**: `quote` 最大1000文字、`memo` 最大2000文字、`page >= 1`。アプリのバグや不正入力があっても DB で破壊的データを防ぐ
+- **digest 保存によるトークンの漏えい耐性**: ログイン時に発行する raw トークンはクライアントへの返却のみとし、DB には SHA256 digest のみ保存する。DB が漏えいしても raw トークンへの復元を防ぐ
+- **トークン失効管理**: `expires_at`（発行から30日）と `revoked_at`（明示的なログアウト）の両方で有効性を管理。`AccessToken.active` スコープで一元チェック
 
 ## API エンドポイント
 
-| Method | Path | 説明 |
-|--------|------|------|
-| GET | `/api/books` | Book 一覧取得 |
-| POST | `/api/books` | Book 作成 |
-| POST | `/api/books/:book_id/notes` | Note 作成 |
-| DELETE | `/api/notes/:id` | Note 削除 |
-| POST | `/api/books/:book_id/notes/bulk` | Note 一括作成（最大20件） |
-| GET | `/api/books/:book_id/notes_search` | Note 検索（キーワード/ページ範囲） |
+認証が必要なエンドポイントには `Authorization: Bearer <token>` ヘッダが必要。
+
+| Method | Path | 認証 | 説明 |
+|--------|------|------|------|
+| POST | `/api/auth/session` | 不要 | ログイン（トークン発行） |
+| DELETE | `/api/auth/session` | 必要 | ログアウト（トークン失効） |
+| GET | `/api/books` | 必要 | 自分の Book 一覧取得 |
+| POST | `/api/books` | 必要 | Book 作成 |
+| POST | `/api/books/:book_id/notes` | 必要 | Note 作成 |
+| DELETE | `/api/notes/:id` | 必要 | Note 削除 |
+| POST | `/api/books/:book_id/notes/bulk` | 必要 | Note 一括作成（最大20件） |
+| GET | `/api/books/:book_id/notes_search` | 必要 | Note 検索（キーワード/ページ範囲） |
 
 詳細は [`docs/40_api/api_overview.md`](docs/40_api/api_overview.md) を参照。
 
@@ -97,15 +117,48 @@ docker compose exec web bin/rails db:seed
 
 ### 動作確認
 
-```bash
-# Book 一覧取得
-curl -i http://localhost:3000/api/books \
-  -H "Accept: application/json"
+> `jq` が必要です。未インストールの場合は `| jq` を省略し、JSON レスポンスから手動でトークンを取得してください。
 
-# Book 作成
-curl -i -X POST http://localhost:3000/api/books \
+```bash
+# ① テストユーザーを作成する（初回のみ）
+docker compose exec web bin/rails runner \
+  "User.find_or_create_by!(email: 'dev@example.com') { |u| u.password = 'password' }"
+
+# ② ログイン → TOKEN を環境変数に入れる
+TOKEN=$(curl -s -X POST http://localhost:3000/api/auth/session \
   -H "Content-Type: application/json" \
-  -d '{"book":{"title":"test","author":"me"}}'
+  -d '{"email":"dev@example.com","password":"password"}' \
+  | jq -r '.token')
+
+echo $TOKEN   # トークンが表示されれば成功
+
+# ③ Book 一覧取得
+curl -s http://localhost:3000/api/books \
+  -H "Authorization: Bearer $TOKEN" | jq
+
+# ④ Book 作成 → BOOK_ID を環境変数に入れる
+BOOK_ID=$(curl -s -X POST http://localhost:3000/api/books \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"book":{"title":"Test Book","author":"Author"}}' \
+  | jq -r '.id')
+
+echo "Book ID: $BOOK_ID"
+
+# ⑤ Note 一括作成
+curl -s -X POST "http://localhost:3000/api/books/$BOOK_ID/notes/bulk" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{
+    "notes": [
+      {"page": 1, "quote": "最初の引用文", "memo": "メモ1"},
+      {"page": 2, "quote": "2番目の引用文", "memo": "メモ2"}
+    ]
+  }' | jq
+
+# ⑥ ログアウト（トークン失効）
+curl -s -X DELETE http://localhost:3000/api/auth/session \
+  -H "Authorization: Bearer $TOKEN" | jq
 ```
 
 ### 停止
@@ -132,14 +185,13 @@ RAILS_ENV=test bin/rails db:prepare
 bundle exec rspec
 ```
 
-現在のテストカバレッジ: 64 examples, 0 failures
-
 ## ディレクトリ構成
 
 ```
 backend/
 ├── app/
 │   ├── controllers/api/      # API コントローラ
+│   │   └── auth/             # 認証コントローラ（session）
 │   ├── models/               # ActiveRecord モデル
 │   ├── services/notes/       # ビジネスロジック
 │   └── errors/               # カスタム例外
@@ -171,8 +223,8 @@ backend/
 
 ### 概要
 
-- **初回アクセス遅延:** 約5秒  
-- **2回目以降:** 約200ms  
+- **初回アクセス遅延:** 約5秒
+- **2回目以降:** 約200ms
 
 この遅延は、**一定時間アクセスが無かった後の最初のリクエストのみ**発生する。
 
@@ -180,7 +232,7 @@ backend/
 
 ### 根本原因
 
-本遅延はアプリケーション性能ではなく、  
+本遅延はアプリケーション性能ではなく、
 **サーバーレスインフラのコールドスタート**によるもの。
 
 - **Fly.io のオートストップ**
@@ -197,19 +249,19 @@ backend/
 
 **遅いリクエスト**
 
-- Total: 約5.1秒  
-- ActiveRecord: 約3.6秒  
+- Total: 約5.1秒
+- ActiveRecord: 約3.6秒
 - **VM 起動直後に発生**
 
 **通常リクエスト**
 
-- Total: 約218ms  
-- ActiveRecord: 約213ms  
+- Total: 約218ms
+- ActiveRecord: 約213ms
 
 これにより：
 
-- SQL 自体は本質的に遅くない  
-- 遅延は **コールドスタート時のみ**発生  
+- SQL 自体は本質的に遅くない
+- 遅延は **コールドスタート時のみ**発生
 - アプリケーションコードやクエリ設計は **ボトルネックではない**
 
 ---
@@ -218,10 +270,10 @@ backend/
 
 ```bash
 # 1回目（コールドスタート）
-time curl -o /dev/null -s https://backend-withered-voice-4962.fly.dev/api/books
+time curl -o /dev/null -s https://backend-withered-voice-4962.fly.dev/healthz
 
 # 2回目（ウォーム）
-time curl -o /dev/null -s https://backend-withered-voice-4962.fly.dev/api/books
+time curl -o /dev/null -s https://backend-withered-voice-4962.fly.dev/healthz
 ```
 ---
 
@@ -229,16 +281,16 @@ time curl -o /dev/null -s https://backend-withered-voice-4962.fly.dev/api/books
 
 考えられる対策：
 
-- Fly.io マシンの常時起動  
-- Neon の有料プラン利用（コールドスタート回避）  
-- 定期 keep-alive ping の導入  
+- Fly.io マシンの常時起動
+- Neon の有料プラン利用（コールドスタート回避）
+- 定期 keep-alive ping の導入
 
 本プロジェクトでは **意図的に未実施**とした。
 
 理由：
 
-- 本アプリは **ポートフォリオ用途**  
-- **完全無料のサーバーレス構成**での運用を前提としている  
+- 本アプリは **ポートフォリオ用途**
+- **完全無料のサーバーレス構成**での運用を前提としている
 - コールドスタート遅延は **仕様上のトレードオフ**であり不具合ではない
 
 ---
@@ -251,8 +303,7 @@ time curl -o /dev/null -s https://backend-withered-voice-4962.fly.dev/api/books
 - **再現性があり説明可能**
 - **無料サーバーレス運用の範囲では許容可能**
 
-したがって、  
+したがって、
 **アプリケーションレベルの最適化は不要**と判断した。
 
 ---
-


### PR DESCRIPTION
## 概要
README を更新し、Bearer トークン認証の導入に伴う API 利用方法と動作確認手順を整理しました。

## 主な変更
- Bearer トークン認証の説明を追加
- 認証フロー（ログイン → API 利用 → ログアウト）の手順を追加
- API エンドポイント一覧を更新（認証要否を明記）
- ER 図を認証モデル（User / AccessToken）を含む構成に更新
- ローカル動作確認手順を認証前提の curl コマンドに更新
- エラーレスポンス形式 `{ error: { code, message, details } }` を反映
- サーバーレス環境（Fly.io + Neon）のコールドスタート説明を整理

## 目的
認証付き API の利用方法を README 単体で理解できるようにし、  
ポートフォリオ閲覧者が **実際の API 呼び出し手順を再現できる状態**にすること。

## 影響範囲
コード変更はなく、ドキュメントのみの更新です。