### PR TITLE
add user registration 

### DIFF
--- a/backend/app/controllers/api/books_controller.rb
+++ b/backend/app/controllers/api/books_controller.rb
@@ -1,5 +1,6 @@
 module Api
   class BooksController < ApplicationController
+    before_action :authenticate_user!
 
     def index
       books = current_user.books.alive.order(created_at: :desc)

--- a/backend/app/controllers/api/notes_controller.rb
+++ b/backend/app/controllers/api/notes_controller.rb
@@ -1,6 +1,7 @@
 module Api
   class NotesController < ApplicationController
 
+    before_action :authenticate_user!
     before_action :set_book, only: [:create]
 
     def create

--- a/backend/app/controllers/api/notes_controller.rb
+++ b/backend/app/controllers/api/notes_controller.rb
@@ -1,7 +1,7 @@
 module Api
   class NotesController < ApplicationController
 
-    before_action :authenticate_user!
+    before_action :authenticate_user!, only: [:create, :destroy]
     before_action :set_book, only: [:create]
 
     def create
@@ -11,7 +11,7 @@ module Api
     end
 
     def destroy
-      note = Note.find(params[:id])
+      note = current_user.book.notes.find(params[:id])
       note.destroy!
       head :no_content
     end

--- a/backend/app/controllers/api/users_controller.rb
+++ b/backend/app/controllers/api/users_controller.rb
@@ -1,0 +1,15 @@
+class Api::UsersController < ApplicationController
+  skip_before_action :authenticate_user!, only: [:create]
+  
+  def create
+    
+    email = params[:email]
+    password = params[:password]
+
+    # has_secure_password により password を渡すと password_digest に保存される
+    User.create!(email: email, password: password)
+    # 
+    render json: {text: "ok"}, status: :created
+    
+  end
+end

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -4,5 +4,6 @@ class User < ApplicationRecord
   has_many :books, dependent: :restrict_with_exception
   has_many :access_tokens, dependent: :destroy
   
-  validates :email, presence: true, uniqueness: true
+  validates :email, presence: true, uniqueness: true, format: { with: /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i }
+
 end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
     namespace :auth do
       resource :session, only: [:create, :destroy]
     end
+    resources :users, only: [:create]
   end
   
   if Rails.env.development?

--- a/backend/docs/30_architecture/notes_destroy_authorization.md
+++ b/backend/docs/30_architecture/notes_destroy_authorization.md
@@ -1,0 +1,19 @@
+# notes#destroy 認可メモ
+
+## 現在の問題
+- `notes#destroy` で `Note.find(params[:id])` を使っている
+- このままだと、current_user の所有範囲外の note に触れられる可能性がある
+
+## 認可の方向性
+- destroy の対象は、current_user が所有している note の中の1件にする
+- 所有関係は `user -> books -> notes` で辿る
+- グローバルな `Note` 全体から取得しない
+
+## 期待する動作
+- 自分の note は削除できる
+- 他人の note は削除できない
+- current_user の所有範囲で見つからなければ失敗として扱う
+
+## 次にやること
+- 今の Rails の関連の中で、所有者スコープ付きの note 集合をどう表現するか決める
+- 実装後、user A / user B で確認する

--- a/backend/spec/requests/api/users_spec.rb
+++ b/backend/spec/requests/api/users_spec.rb
@@ -1,0 +1,102 @@
+require 'rails_helper'
+
+RSpec.describe "Api::Users", type: :request do
+  let!(:example_user) do
+    User.create!(
+      email: "abab@example.com",
+      password: "password"
+    )
+  end
+
+
+  describe "POST /api/users" do
+
+    context "正常系" do
+      it "emailとパスワードが登録できること" do
+        post "/api/users",
+          params: { email: "note-spec-#{SecureRandom.hex(4)}@example.com", password: "password"} ,
+          as: :json
+          # puts response.body
+          expect(response).to have_http_status(:created)
+      end
+    end
+
+    context "異常系" do
+
+      context "必須" do
+        it "emailが空文字" do
+   
+          post "/api/users",
+                params: { email: "", password: "password" },
+                as: :json
+          
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+    
+        it "パスワードが空文字" do
+          post "/api/users",
+              params: { email: "note-spec-#{SecureRandom.hex(4)}@example.com", password: ""},
+              as: :json
+          
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+    
+       
+        it "emailがnil" do
+       
+          post "/api/users",
+                params: { email: nil, password: "password" },
+                as: :json
+    
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+    
+        it "パスワードがnil" do
+       
+          post "/api/users",
+                params: { email: "note-spec-#{SecureRandom.hex(4)}@example.com", password: nil },
+                as: :json
+          
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+        it "emailのキー自体がない" do
+        
+          post "/api/users",
+                params: { password: "password" },
+                as: :json
+    
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+    
+        it "パスワードのキー自体がない" do
+        
+          post "/api/users",
+                params: { email: "note-spec-#{SecureRandom.hex(4)}@example.com" },
+                as: :json
+          
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+      end
+      context "重複" do
+        it "すでに登録してあるemailで再度登録しようとした場合" do
+      
+          post "/api/users",
+                params: { email: "abab@example.com", password: "password"},
+                as: :json
+          
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+      end
+
+      context "形式不正" do
+        it "emailの形式不正" do
+          post "/api/users",
+            params: { email: "note-spec-#{SecureRandom.hex(4)}example.com", password: "password"} ,
+            as: :json
+    
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+      end
+    end
+  end
+end

--- a/backend/spec/requests/auth/authentication_spec.rb
+++ b/backend/spec/requests/auth/authentication_spec.rb
@@ -14,19 +14,40 @@ RSpec.describe "Authentication", type: :request, auth: :real do
   end
 
   describe "GET /api/books" do
-    it "returns 401 without Authorization header" do
-      get "/api/books"
 
-      expect(response).to have_http_status(:unauthorized)
+    context "正常系" do
+      it "returns 200 with valid Bearer token" do
+        token = login_and_get_token
+  
+        get "/api/books",
+            headers: { "Authorization" => "Bearer #{token}" }
+  
+        expect(response).to have_http_status(:ok)
+      end
+      
     end
 
-    it "returns 200 with valid Bearer token" do
-      token = login_and_get_token
+    context "異常系" do
+      it "returns 401 without Authorization header" do
+        get "/api/books"
+  
+        expect(response).to have_http_status(:unauthorized)
+        puts response.body
+      end
 
-      get "/api/books",
-          headers: { "Authorization" => "Bearer #{token}" }
+      it "authorizationのtokenがクライアントからのrawの情報でない場合" do
+        get "/api/books",
+          headers: { "Authorization" => "Bearer aaaaaaooooo" },
+          as: :json
+        puts response.body
 
-      expect(response).to have_http_status(:ok)
+        expect(response).to have_http_status(:unauthorized)
+
+        
+      end
     end
+
+
+
   end
 end

--- a/backend/spec/requests/auth/authentication_spec.rb
+++ b/backend/spec/requests/auth/authentication_spec.rb
@@ -42,8 +42,14 @@ RSpec.describe "Authentication", type: :request, auth: :real do
         puts response.body
 
         expect(response).to have_http_status(:unauthorized)
+      end
 
-        
+      it "Authorization header が Bearer のみのとき 401" do
+        get "/api/books",
+        headers: { "Authorization" => "Bearer " },
+        as: :json
+
+        expect(response).to have_http_status(:unauthorized)
       end
     end
 

--- a/backend/spec/requests/auth/authentication_spec.rb
+++ b/backend/spec/requests/auth/authentication_spec.rb
@@ -1,4 +1,5 @@
 require "rails_helper"
+require "digest"
 
 RSpec.describe "Authentication", type: :request, auth: :real do
   let!(:user) { User.create!(email: "me@example.com", password: "password") }
@@ -14,6 +15,8 @@ RSpec.describe "Authentication", type: :request, auth: :real do
   end
 
   describe "GET /api/books" do
+    let(:email) { "auth-spec-#{SecureRandom.hex(4)}@example.com" }
+    let(:password) { "password" }
 
     context "正常系" do
       it "returns 200 with valid Bearer token" do
@@ -51,9 +54,29 @@ RSpec.describe "Authentication", type: :request, auth: :real do
 
         expect(response).to have_http_status(:unauthorized)
       end
+
+      it "Authorization header が Bearer ではあるが、token が active 条件を満たさないとき 401" do
+
+        user = User.create!(email: email, password: password)
+  
+        raw = SecureRandom.hex(32)
+        digest = Digest::SHA256.hexdigest(raw)
+  
+        AccessToken.create!(
+          user: user,
+          token_digest: digest,
+          expires_at: 1.second.ago
+        )
+  
+        get "/api/books",
+        headers: { "Authorization" => "Bearer #{raw}"},
+        as: :json
+  
+        expect(response).to have_http_status(:unauthorized)
+
+        puts response.body
+  
+      end
     end
-
-
-
   end
 end

--- a/backend/spec/requests/auth/session_spec.rb
+++ b/backend/spec/requests/auth/session_spec.rb
@@ -4,13 +4,20 @@ RSpec.describe "Api::Auth::Session", type: :request, auth: :real do
   let!(:user) { User.create!(email: "me@example.com", password: "password", password_confirmation: "password") }
 
   describe "POST /api/auth/session" do
+    let(:email) { "auth-spec-#{SecureRandom.hex(4)}@example.com" }
+    let(:password) { "password" }
 
     context "正常系" do
       it "returns token on success" do
         post "/api/auth/session", params: { email: user.email, password: "password" }, as: :json
         expect(response).to have_http_status(:ok)
+
+        puts response.body
+
   
         body = JSON.parse(response.body)
+
+        puts body["token"]
         expect(body["token"]).to be_present
       end
 
@@ -18,6 +25,28 @@ RSpec.describe "Api::Auth::Session", type: :request, auth: :real do
         expect {
           post "/api/auth/session", params: { email: user.email, password: "password" }, as: :json
         }.to change(AccessToken, :count).by(1)
+      end
+
+
+      it "ログイン成功時、raw tokenは返るがDBにはdigestしか保存されない" do
+        post "/api/auth/session", params: { email: user.email, password: "password" }, as: :json
+        expect(response).to have_http_status(:ok)
+        # 
+
+        body = JSON.parse(response.body)
+        puts "トークンの内容 #{body["token"]}"
+
+        responseDigest = Digest::SHA256.hexdigest(body["token"])
+
+        user1 = User.find_by(email: user.email)
+
+        user_AccessToken = AccessToken.find_by(user: user1)
+        puts "digest #{user_AccessToken.token_digest}"
+
+        expect(body["token"]).not_to eq(user_AccessToken.token_digest)
+        expect(responseDigest).to eq(user_AccessToken.token_digest)
+
+        #dbのカラムの確認をする
       end
             
     end

--- a/backend/spec/requests/auth/session_spec.rb
+++ b/backend/spec/requests/auth/session_spec.rb
@@ -1,42 +1,73 @@
+require "rails_helper"
+
 RSpec.describe "Api::Auth::Session", type: :request, auth: :real do
   let!(:user) { User.create!(email: "me@example.com", password: "password", password_confirmation: "password") }
 
   describe "POST /api/auth/session" do
-    it "returns token on success" do
-      post "/api/auth/session", params: { email: user.email, password: "password" }, as: :json
-      expect(response).to have_http_status(:ok)
 
-      body = JSON.parse(response.body)
-      expect(body["token"]).to be_present
+    context "正常系" do
+      it "returns token on success" do
+        post "/api/auth/session", params: { email: user.email, password: "password" }, as: :json
+        expect(response).to have_http_status(:ok)
+  
+        body = JSON.parse(response.body)
+        expect(body["token"]).to be_present
+      end
+
+      it "ログインが成功しAccessTokenが一件増えるはず" do 
+        expect {
+          post "/api/auth/session", params: { email: user.email, password: "password" }, as: :json
+        }.to change(AccessToken, :count).by(1)
+      end
+            
     end
 
-    it "returns 401 on invalid credentials" do
-      post "/api/auth/session", params: { email: user.email, password: "wrong" }, as: :json
-      expect(response).to have_http_status(:unauthorized)
+    context "異常系" do
+      it "returns 401 on invalid credentials" do
+        post "/api/auth/session", params: { email: user.email, password: "wrong" }, as: :json
+        expect(response).to have_http_status(:unauthorized)
+      end
     end
   end
 
   describe "auth + logout flow" do
-    it "blocks without bearer and blocks after logout" do
-      # no bearer -> 401
-      get "/api/books"
-      expect(response).to have_http_status(:unauthorized)
-
-      # login -> token
-      post "/api/auth/session", params: { email: user.email, password: "password" }, as: :json
-      token = JSON.parse(response.body).fetch("token")
-
-      # bearer -> 200
-      get "/api/books", headers: { "Authorization" => "Bearer #{token}" }
-      expect(response).to have_http_status(:ok)
-
-      # logout -> 200
-      delete "/api/auth/session", headers: { "Authorization" => "Bearer #{token}" }
-      expect(response).to have_http_status(:ok)
-
-      # same bearer -> 401
-      get "/api/books", headers: { "Authorization" => "Bearer #{token}" }
-      expect(response).to have_http_status(:unauthorized)
+    context "正常系" do
+      
     end
+
+    context "異常系" do
+      it "blocks without bearer and blocks after logout" do
+        # no bearer -> 401
+        get "/api/books"
+        expect(response).to have_http_status(:unauthorized)
+  
+        # login -> token
+        post "/api/auth/session", params: { email: user.email, password: "password" }, as: :json
+        token = JSON.parse(response.body).fetch("token")
+  
+        # bearer -> 200
+        get "/api/books", headers: { "Authorization" => "Bearer #{token}" }
+        expect(response).to have_http_status(:ok)
+  
+        # logout -> 200
+        delete "/api/auth/session", headers: { "Authorization" => "Bearer #{token}" }
+        expect(response).to have_http_status(:ok)
+  
+        # same bearer -> 401
+        get "/api/books", headers: { "Authorization" => "Bearer #{token}" }
+        expect(response).to have_http_status(:unauthorized)
+      end
+
+      it "ログインが成功せずAccessTokenは増えない" do
+        expect {
+          post "/api/auth/session", params: { email: "", password: "password" }, as: :json
+        }.not_to change(AccessToken, :count)
+
+        expect(response).to have_http_status(:unauthorized)
+                
+      end 
+            
+    end 
+
   end
 end


### PR DESCRIPTION
- ユーザー登録APIの追加

- Book / Note 系APIへの認証適用
  - 未認証時のアクセスを防ぐよう修正

- Note削除時の所有者スコープ修正
  - note.destroyをcurrent_userの所有範囲内から対象を取得するよう修正

- ユーザー登録と認証に関するrequest specを追加・更新
  - ユーザー登録の正常系・異常系のテストケースを追加
  - token保存形式や認証失敗ケースを追加

- emailの入力バリデーションの強化