### PR TITLE
chore: move fly.toml and add release command

### DIFF
--- a/backend/fly.toml
+++ b/backend/fly.toml
@@ -25,3 +25,6 @@ console_command = '/rails/bin/rails console'
   memory = '1gb'
   cpus = 1
   memory_mb = 1024
+
+[deploy]
+  release_command = "bin/rails db:prepare"


### PR DESCRIPTION
- fly.tomlファイルの移動
  - アプリのルートディレクトリに位置していたため、tomlの内容を読んでもらうことができなかったためbackendのルートに移動

- release_commandを追加
  - デプロイ時、rails db:prepareを実行し、本番DBに準備・未適用migrationの反映漏れを防ぐために追加

