### PR TITLE
add books owner scope spec and authentication docs

### DIFF
--- a/backend/docs/40_api/authentication_request_specs.md
+++ b/backend/docs/40_api/authentication_request_specs.md
@@ -1,0 +1,9 @@
+## Request spec authentication policy
+
+Request specs are divided by responsibility.
+
+- `authentication_spec` はトークン未指定・不正なトークン・有効なトークンなど、認証そのものの挙動を確認する
+- books_specでは認証済みユーザーがいる前提で、Book Apiのレスポンス構造や所有権スコープを確認する
+- 通常の機能ごとのrequest specでは、ログイン処理を毎回検証するのではなく、各specの責務に集中するために認証をstubする
+- 実際の認証フローを確認する必要があるspecでは、autj: :realを使って認証stubを回避する
+- book indexの所有権specでは、response bodyに認証済みユーザー本人のBookだけが含まれ、他ユーザーのBookが含まれないことを確認する。

--- a/backend/docs/40_api/authentication_request_specs.md
+++ b/backend/docs/40_api/authentication_request_specs.md
@@ -3,7 +3,7 @@
 Request specs are divided by responsibility.
 
 - `authentication_spec` はトークン未指定・不正なトークン・有効なトークンなど、認証そのものの挙動を確認する
-- books_specでは認証済みユーザーがいる前提で、Book Apiのレスポンス構造や所有権スコープを確認する
+- books_specでは認証済みユーザーがいる前提で、Books APIのレスポンス構造や所有権スコープを確認する
 - 通常の機能ごとのrequest specでは、ログイン処理を毎回検証するのではなく、各specの責務に集中するために認証をstubする
-- 実際の認証フローを確認する必要があるspecでは、autj: :realを使って認証stubを回避する
-- book indexの所有権specでは、response bodyに認証済みユーザー本人のBookだけが含まれ、他ユーザーのBookが含まれないことを確認する。
+- 実際の認証フローを確認する必要があるspecでは、`auth: :real`を使って認証stubを回避する
+- books indexの所有権specでは、response bodyに認証済みユーザー本人のBookだけが含まれ、他ユーザーのBookが含まれないことを確認する。

--- a/backend/spec/requests/api/books_spec.rb
+++ b/backend/spec/requests/api/books_spec.rb
@@ -5,7 +5,14 @@ require "rails_helper"
 RSpec.describe "Api::Books", type: :request do
   let!(:user) do
     User.create!(
-      email: "books-spec-#{SecureRandom.hex(4)}@example.com",
+      email: "books1-spec-#{SecureRandom.hex(4)}@example.com",
+      password: "password"
+    )
+  end
+
+  let!(:user2) do
+    User.create!(
+      email: "books2-spec-#{SecureRandom.hex(4)}@example.com",
       password: "password"
     )
   end
@@ -15,38 +22,66 @@ RSpec.describe "Api::Books", type: :request do
   end
 
   describe "GET /api/books" do
-    it "returns 200 with an array" do
-      Book.create!(user: user, title: "Book A", author: "Author A")
-      Book.create!(user: user, title: "Book B", author: "Author B")
+    context "正常系" do
+      it "returns 200 with an array" do
+        Book.create!(user: user, title: "Book A", author: "Author A")
+        Book.create!(user: user, title: "Book B", author: "Author B")
 
-      get "/api/books"
+        get "/api/books"
 
-      expect(response).to have_http_status(:ok)
-      json = JSON.parse(response.body)
-      expect(json).to be_an(Array)
-      expect(json.first).to include("id", "title", "author")
+        expect(response).to have_http_status(:ok)
+        json = JSON.parse(response.body)
+        expect(json).to be_an(Array)
+        expect(json.first).to include("id", "title", "author")
+      end
+
+      it "returns 200 with books ordered by created_at desc" do
+        Book.create!(
+          user: user,
+          title: "Book A",
+          author: "A",
+          created_at: Time.zone.parse("2020-01-01 00:00:00")
+        )
+        Book.create!(
+          user: user,
+          title: "Book B",
+          author: "B",
+          created_at: Time.zone.parse("2020-01-02 00:00:00")
+        )
+
+        get "/api/books"
+
+        expect(response).to have_http_status(:ok)
+        json = JSON.parse(response.body)
+        expect(json.map { _1.keys }).to all(include("id", "title", "author"))
+        expect(json.map { _1["title"] }).to eq(["Book B", "Book A"])
+      end
+
+      it "認証済みユーザーのbookのみ返る" do
+        book = Book.create!(
+          user: user,
+          title: "Book B",
+          author: "B",
+          created_at: Time.zone.parse("2020-01-02 00:00:00")
+        )
+        book2 = Book.create!(
+          user: user2,
+          title: "userBook 2",
+          author: "user2",
+          created_at: Time.zone.parse("2020-01-03 00:00:00")
+        )
+        get "/api/books"
+
+        json = JSON.parse(response.body)
+        ids = json.map { |book| book["id"] }
+
+        expect(ids).to include(book.id)
+        expect(ids).not_to include(book2.id)
+      end
     end
 
-    it "returns 200 with books ordered by created_at desc" do
-      Book.create!(
-        user: user,
-        title: "Book A",
-        author: "A",
-        created_at: Time.zone.parse("2020-01-01 00:00:00")
-      )
-      Book.create!(
-        user: user,
-        title: "Book B",
-        author: "B",
-        created_at: Time.zone.parse("2020-01-02 00:00:00")
-      )
+    context "異常系" do  
 
-      get "/api/books"
-
-      expect(response).to have_http_status(:ok)
-      json = JSON.parse(response.body)
-      expect(json.map { _1.keys }).to all(include("id", "title", "author"))
-      expect(json.map { _1["title"] }).to eq(["Book B", "Book A"])
     end
   end
 


### PR DESCRIPTION
- 認証済みユーザー本人に紐づくbooksが返るテストを追加
  - books_specにて認証stubにより認証済みユーザーとして扱われるユーザーのbookのみresponse bodyに含まれることをチェック、他の人のbookがresponse bodyに含まれていないこともチェック

- authentication policyドキュメントを追加
  - 主にアプリ内のstubの仕様等について記載。所有権scopeに対しての説明、実際の認証フローを確認する場合に、auth: :realで認証stubを回避する方針
