### PR TITLE
Update user creation response and add revoked token spec

### DIFF
--- a/backend/app/controllers/api/users_controller.rb
+++ b/backend/app/controllers/api/users_controller.rb
@@ -3,8 +3,9 @@ class Api::UsersController < ApplicationController
   
   def create
     # has_secure_password により password を渡すと password_digest に保存される
-    User.create!(users_params)
-    render json: {text: "ok"}, status: :created
+    user = User.create!(users_params)
+    render json: user.as_json(only: [:id, :name, :email]), status: :created
+    
     
   end
 

--- a/backend/spec/requests/api/users_spec.rb
+++ b/backend/spec/requests/api/users_spec.rb
@@ -18,6 +18,25 @@ RSpec.describe "Api::Users", type: :request do
           as: :json
           expect(response).to have_http_status(:created)
       end
+
+      it "ユーザー作成成功時にid,name,emailを返し、password_digestを返さない" do
+        name = "test"
+        email = "notes-spec-#{SecureRandom.hex(4)}@example.com"
+
+        post "/api/users",
+          params: { user: { name: name, email: email, password: "password", password_confirmation: "password"}}, 
+          as: :json
+
+          json = JSON.parse(response.body)
+
+          user_byemail = User.find_by(email: email)
+
+          expect(json["name"]).to eq(name)
+          expect(json["email"]).to eq(email)
+          expect(json["id"]).to eq(user_byemail.id)
+          expect(json.key?("password_digest")).to eq(false)
+      end
+        
     end
 
     context "異常系" do

--- a/backend/spec/requests/auth/authentication_spec.rb
+++ b/backend/spec/requests/auth/authentication_spec.rb
@@ -77,6 +77,24 @@ RSpec.describe "Authentication", type: :request, auth: :real do
         puts response.body
   
       end
+
+      it "revoked_atが設定されたtokenでGET /api/booksが401になること" do
+        token = login_and_get_token
+  
+        get "/api/books",
+            headers: { "Authorization" => "Bearer #{token}" }
+        expect(response).to have_http_status(:ok)
+
+        digest = Digest::SHA256.hexdigest(token)
+        find_token = AccessToken.find_by(token_digest: digest)
+
+        find_token.update!(revoked_at: Time.current)
+
+        get "/api/books",
+
+            headers: { "Authorization" => "Bearer #{token}" }
+        expect(response).to have_http_status(:unauthorized)
+      end
     end
   end
 end

--- a/backend/spec/requests/auth/session_spec.rb
+++ b/backend/spec/requests/auth/session_spec.rb
@@ -59,13 +59,13 @@ RSpec.describe "Api::Auth::Session", type: :request, auth: :real do
     end
   end
 
-  describe "auth + logout flow" do
+  describe "DELETE /api/auth/session" do
     context "正常系" do
       
     end
 
     context "異常系" do
-      it "blocks without bearer and blocks after logout" do
+      it "Bearer tokenなしのアクセスと、logout後の同じtokenでのアクセスを拒否する" do
         # no bearer -> 401
         get "/api/books"
         expect(response).to have_http_status(:unauthorized)


### PR DESCRIPTION
- ユーザー作成APIレスポンス仕様を変更
  - ユーザー作成後、今までrenderで{ text: "ok" }だけ返していたのを、json形式でuser登録内容の:id, :name, :emailを返す仕様に変更。rspecのテストもそれに準じて:id, :name, :emailを返すこととpassword_digestがレスポンスに含まれない確認

- 認証関連specを追加・整理
  - session_specではテストケースの粒度とテストタイトルの微修正。authentication_specでは一度発行されたtokenにrevoked_atが設定されたあと、そのtokenで保護apiへのアクセスが401エラーになるテストを実装

