### PR TITLE
feat: add book soft delete and align access boundaries

### DIFF
--- a/backend/app/controllers/api/books_controller.rb
+++ b/backend/app/controllers/api/books_controller.rb
@@ -13,6 +13,12 @@ module Api
       render json: book.as_json(only: [:id, :title, :author]), status: :created
     end
 
+    def destroy
+      book = current_user.books.alive.find(params[:id])
+      book.update(deleted_at: Time.current)
+      head :no_content
+    end
+
     private
 
     def book_params

--- a/backend/app/controllers/api/notes_bulk_controller.rb
+++ b/backend/app/controllers/api/notes_bulk_controller.rb
@@ -1,12 +1,14 @@
 class Api::NotesBulkController < ApplicationController
+  before_action :authenticate_user!, only: [:create]
+  before_action :set_book, only: [:create]
 
 
-  # Book の存在確認は Notes::BulkCreate 側で行う（Controller で二重にDBを叩かない）
   def create
     notes = Notes::BulkCreate.call(
-      book_id: params[:book_id],
+      book: @book,
       notes_params: notes_params
     )
+
 
     render json: {
       notes: notes.as_json(only: [:id, :page, :quote, :memo, :created_at]),
@@ -24,6 +26,10 @@ class Api::NotesBulkController < ApplicationController
   # ApplicationController 側の rescue に任せる。
   #
   # バリデーションや一括作成のルールは Service に寄せる。
+  
+  def set_book
+    @book = current_user.books.alive.find(params[:book_id])
+  end
 
   def notes_params
     raw = params[:notes]

--- a/backend/app/controllers/api/notes_search_controller.rb
+++ b/backend/app/controllers/api/notes_search_controller.rb
@@ -1,10 +1,11 @@
 module Api
   class NotesSearchController < ApplicationController
-
+    before_action :authenticate_user!, only: [:index]
+    before_action :set_book, only: [:index]
 
     def index
       notes, meta = Notes::SearchNotes.call(
-        book_id:   params[:book_id],
+        book: @book,
         query:     params[:q],
         page_from: params[:page_from],
         page_to:   params[:page_to],
@@ -18,6 +19,10 @@ module Api
         ),
         meta:  meta
       }
+    end
+
+    def set_book
+      @book = current_user.books.alive.find(params[:book_id])
     end
 
 

--- a/backend/app/services/notes/bulk_create.rb
+++ b/backend/app/services/notes/bulk_create.rb
@@ -12,15 +12,13 @@ module Notes
 
     MAX_NOTES_PER_REQUEST = 20
 
-    def self.call(book_id:, notes_params:)
+    def self.call(book:, notes_params:)
       unless notes_params.is_a?(Array) && notes_params.any?
         raise ApplicationErrors::BadRequest, "notes must be a non-empty array"
       end
       if notes_params.size > MAX_NOTES_PER_REQUEST
         raise ApplicationErrors::BadRequest, "too many notes (max #{MAX_NOTES_PER_REQUEST})"
       end
-
-      book  = Book.alive.find(book_id) 
 
       notes  = []
       errors = []

--- a/backend/app/services/notes/search_notes.rb
+++ b/backend/app/services/notes/search_notes.rb
@@ -6,25 +6,19 @@ module Notes
 
     # ==== 公開インターフェース ====
     # Controller からはここだけ呼ぶ
-    def self.call(book_id:, query: nil, page_from: nil, page_to: nil, page: nil, limit: nil)
+    def self.call(book:, query: nil, page_from: nil, page_to: nil, page: nil, limit: nil)
       params = normalize_params(
-        book_id: book_id,
         query: query,
         page_from: page_from,
         page_to: page_to,
         page: page,
         limit: limit
       )
-      book = Book.alive.find(params[:book_id])
-      # ① 入力を Service 内部用に正規化
 
-      # ② 検索条件を組み立てる
       rel = build_scope(book, params)
 
-      # ③ 件数カウント
       total_count = rel.count
 
-      # ④ ページネーション適用
       records, meta = paginate(rel, params[:page], params[:limit], total_count)
 
       [records, meta]
@@ -34,8 +28,7 @@ module Notes
 
     # Controller 由来の値（文字列・nil・変な値）を
     # Service 内部で扱いやすい形にそろえる
-    def self.normalize_params(book_id:, query:, page_from:, page_to:, page:, limit:)
-      raise ApplicationErrors::BadRequest, "book_id must be a numeric string" unless book_id.to_s =~ /\A\d+\z/
+    def self.normalize_params(query:, page_from:, page_to:, page:, limit:)
 
       if page.present? && page.to_s !~ /\A\d+\z/
         raise ApplicationErrors::BadRequest, "page must be an integer or nil"
@@ -65,7 +58,6 @@ module Notes
     
 
       {
-        book_id: book_id.to_i,
         query:     query&.to_s&.strip&.presence,
         page_from: page_from_i,
         page_to:   page_to_i,

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
    get "/healthz", to: "health#show"
 
   namespace :api do
-    resources :books, only: [:index, :create] do
+    resources :books, only: [:index, :create, :destroy] do
       resources :notes, only: [:create, :destroy]
       resources :notes_search, only: [:index], path: "notes_search"
 

--- a/backend/spec/requests/api/books_spec.rb
+++ b/backend/spec/requests/api/books_spec.rb
@@ -109,6 +109,30 @@ RSpec.describe "Api::Books", type: :request do
         expect(deleted_book.deleted_at).not_to be_nil
 
       end
+
+      it "認証済みユーザーは他人のbookを削除できない" do
+        anotherUserBook = Book.create!(
+          user: user2,
+          title: "another User Book",
+          author: "Mr.another",
+          created_at: Time.zone.parse("2020-01-05 00:00:00")
+        )
+
+        another_id = anotherUserBook.id
+
+        delete "/api/books/#{another_id}"
+        json2 = JSON.parse(response.body)
+
+        expect(json2["error"]["code"]).to eq(:not_found)
+
+        expect(response.status).to eq(404)
+        
+        another_book = user2.books.alive.find(another_id)
+
+        expect(another_book.deleted_at).to be_nil
+        expect(Book.exists?(anotherUserBook.id)).to eq(true)
+
+      end
     end
 
     context "異常系" do  

--- a/backend/spec/requests/api/books_spec.rb
+++ b/backend/spec/requests/api/books_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe "Api::Books", type: :request do
         expect(ids).not_to include(book2.id)
       end
 
-      it "認証済みユーザーが自分のbookを削除できる" do
+      it "（論理削除）認証済みユーザーが自分のbookを削除すると204を返し、その後一覧から除去されdeleted_atが入ること" do
         book = Book.create!(
           user: user,
           title: "Book C",
@@ -92,14 +92,22 @@ RSpec.describe "Api::Books", type: :request do
         
         expect(json.map{|n| n["title"]}).to include("Book C")
         
-        id = json.map { |n| n["id"] }[0]
+        id = book.id
 
         delete "/api/books/#{id}"
-        get "/api/books"
+        delete_response_status = response.status
 
+        expect(delete_response_status).to eq(204)
+        
+        get "/api/books"
         json = JSON.parse(response.body)
 
+
         expect(json.map{|n| n["title"]}).not_to include("Book C")
+
+        deleted_book = user.books.find(id)
+        expect(deleted_book.deleted_at).not_to be_nil
+
       end
     end
 

--- a/backend/spec/requests/api/books_spec.rb
+++ b/backend/spec/requests/api/books_spec.rb
@@ -78,6 +78,29 @@ RSpec.describe "Api::Books", type: :request do
         expect(ids).to include(book.id)
         expect(ids).not_to include(book2.id)
       end
+
+      it "認証済みユーザーが自分のbookを削除できる" do
+        book = Book.create!(
+          user: user,
+          title: "Book C",
+          author: "Mr.C",
+          created_at: Time.zone.parse("2020-01-04 00:00:00")
+        )
+
+        get "/api/books"
+        json = JSON.parse(response.body)
+        
+        expect(json.map{|n| n["title"]}).to include("Book C")
+        
+        id = json.map { |n| n["id"] }[0]
+
+        delete "/api/books/#{id}"
+        get "/api/books"
+
+        json = JSON.parse(response.body)
+
+        expect(json.map{|n| n["title"]}).not_to include("Book C")
+      end
     end
 
     context "異常系" do  

--- a/backend/spec/requests/api/books_spec.rb
+++ b/backend/spec/requests/api/books_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe "Api::Books", type: :request do
         delete "/api/books/#{another_id}"
         json2 = JSON.parse(response.body)
 
-        expect(json2["error"]["code"]).to eq(:not_found)
+        expect(json2["error"]["code"]).to eq("not_found")
 
         expect(response.status).to eq(404)
         

--- a/backend/spec/requests/api/notes_bulk_spec.rb
+++ b/backend/spec/requests/api/notes_bulk_spec.rb
@@ -90,6 +90,32 @@ RSpec.describe "POST /api/books/:book_id/notes/bulk", type: :request do
       expect(first_error).to have_key(:messages)
       expect(first_error[:messages]).to be_an(Array)
     end
+
+    it "他人のbookではbulk作成できない" do
+      other_user = User.create!(
+        email: "other-#{SecureRandom.hex(4)}@example.com",
+        password: "password"
+      )
+      other_book = Book.create!(
+        user: other_user,
+        title: "Other Book",
+        author: "Other Author"
+      )
+
+      payload = {
+          notes: [
+            { page: 1, quote: "Q1", memo: "M1" },
+            { page: 2, quote: "Q2", memo: "M2" },
+            { page: 3, quote: "Q3", memo: "M3" }
+          ]
+        }
+
+      expect {
+        post "/api/books/#{other_book.id}/notes/bulk", params: payload, as: :json
+      }.not_to change { Note.count }
+        
+      expect(response).to have_http_status(:not_found)
+    end
   end
 
   describe "BadRequest → 400 を返す" do

--- a/backend/spec/requests/api/notes_search_spec.rb
+++ b/backend/spec/requests/api/notes_search_spec.rb
@@ -67,6 +67,22 @@ RSpec.describe "Notes Search API", type: :request do
       
         expect(response).to have_http_status(:not_found)
       end
+
+      it "他人のbookではsearchできない" do
+        other_user = User.create!(
+        email: "other-#{SecureRandom.hex(4)}@example.com",
+        password: "password"
+        )
+        other_book = Book.create!(
+          user: other_user,
+          title: "Other Book",
+          author: "Other Author"
+        )
+
+        get "/api/books/#{other_book.id}/notes_search", params: { q: "ruby", page: 1, limit: 10 }
+
+        expect(response).to have_http_status(:not_found) 
+      end
     end
 
     context "400系（BadRequest）" do

--- a/backend/spec/services/notes/bulk_create_spec.rb
+++ b/backend/spec/services/notes/bulk_create_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Notes::BulkCreate do
 
       it "2件とも作成されて戻り値にも含まれる" do
         expect {
-          result = described_class.call(book_id: book.id, notes_params: params)
+          result = described_class.call(book: book, notes_params: params)
 
           expect(result.size).to eq 2
           expect(result.map(&:quote)).to match_array %w[hello world]
@@ -41,7 +41,7 @@ RSpec.describe Notes::BulkCreate do
 
       it "BulkInvalid を投げ、1件も作成されない" do
         expect {
-          described_class.call(book_id: book.id, notes_params: params)
+          described_class.call(book: book, notes_params: params)
         }.to raise_error(Notes::BulkCreate::BulkInvalid) { |e|
           expect(e.errors.size).to eq 1
           expect(e.errors.first[:index]).to eq 0
@@ -52,41 +52,15 @@ RSpec.describe Notes::BulkCreate do
       end
     end
 
-    context "when book is soft-deleted" do
-      let(:params) { [{ page: 1, quote: "ok", memo: nil }] }   
-      it "raises ActiveRecord::RecordNotFound" do
-        book.update!(deleted_at: Time.current)
-    
-        expect {
-          described_class.call(book_id: book.id, notes_params: params)
-        }.to raise_error(ActiveRecord::RecordNotFound)
-      end
-    end
-
-
     context "前提違反: notes が配列じゃないとき" do
       it "BadRequest を投げ、1件も作成されない" do
         expect {
-          described_class.call(book_id: book.id, notes_params: "x")
+          described_class.call(book: book, notes_params: "x")
         }.to raise_error(ApplicationErrors::BadRequest, /notes must be a non-empty array/)
 
         expect(Note.where(book_id: book.id).count).to eq 0
       end
     end
-
-
-    context "前提違反: book が存在しないとき" do
-      it "ActiveRecord::RecordNotFound を投げ、1件も作成されない" do
-        params = [{ page: 1, quote: "ok", memo: nil }]
-
-        expect {
-          described_class.call(book_id: 999_999, notes_params: params)
-        }.to raise_error(ActiveRecord::RecordNotFound)
-
-        expect(Note.where(book_id: book.id).count).to eq 0
-      end
-    end
-
 
     context "バリデーション失敗: 複数行が invalid のとき" do
       let(:params) do
@@ -99,7 +73,7 @@ RSpec.describe Notes::BulkCreate do
 
       it "BulkInvalid を投げ、errors が複数要素で返る & 1件も作成されない" do
         expect {
-          described_class.call(book_id: book.id, notes_params: params)
+          described_class.call(book: book, notes_params: params)
         }.to raise_error(Notes::BulkCreate::BulkInvalid) { |e|
           expect(e.errors.size).to eq 2
 
@@ -118,7 +92,7 @@ RSpec.describe Notes::BulkCreate do
     context "前提違反: notes が空配列のとき" do
       it "BadRequest を投げ、1件も作成されない" do
         expect {
-          described_class.call(book_id: book.id, notes_params: [])
+          described_class.call(book: book, notes_params: [])
         }.to raise_error(ApplicationErrors::BadRequest, /must be a non-empty array/)
     
         expect(Note.where(book_id: book.id).count).to eq 0
@@ -134,7 +108,7 @@ RSpec.describe Notes::BulkCreate do
     
       it "BadRequest を投げ、1件も作成されない" do
         expect {
-          described_class.call(book_id: book.id, notes_params: over_params)
+          described_class.call(book: book, notes_params: over_params)
         }.to raise_error(ApplicationErrors::BadRequest, /too many notes/)
     
         expect(Note.where(book_id: book.id).count).to eq 0
@@ -175,7 +149,7 @@ RSpec.describe Notes::BulkCreate do
       it "save! 失敗時に transaction が rollback し、DB に 1件も作成されない" do
         expect {
           begin
-            described_class.call(book_id: book.id, notes_params: params)
+            described_class.call(book: book, notes_params: params)
           rescue ActiveRecord::RecordInvalid
             # save! の例外は想定内（無視）
           end

--- a/backend/spec/services/notes/search_notes_spec.rb
+++ b/backend/spec/services/notes/search_notes_spec.rb
@@ -35,11 +35,11 @@ RSpec.describe Notes::SearchNotes, type: :service do
       Note.create!(book: book, page: 2, quote: "c", memo: nil)
     
       notes_blank, meta_blank = described_class.call(
-        book_id: book.id, query: "   ", page_from: nil, page_to: nil, page: 1, limit: 50
+        book: book, query: "   ", page_from: nil, page_to: nil, page: 1, limit: 50
       )
     
       notes_nil, meta_nil = described_class.call(
-        book_id: book.id, query: nil, page_from: nil, page_to: nil, page: 1, limit: 50
+        book: book, query: nil, page_from: nil, page_to: nil, page: 1, limit: 50
       )
     
       expect(notes_blank).to match_array(notes_nil)
@@ -48,7 +48,7 @@ RSpec.describe Notes::SearchNotes, type: :service do
 
     it '何もフィルタしないとき、全件・meta が正しい' do
       notes, meta = described_class.call(
-        book_id:   book.id,
+        book:   book,
         query:     nil,
         page_from: nil,
         page_to:   nil,
@@ -67,7 +67,7 @@ RSpec.describe Notes::SearchNotes, type: :service do
 
     it 'query を指定するとその文字列を含むノートだけ返す' do
       notes, meta = described_class.call(
-        book_id:   book.id,
+        book:   book,
         query:     "foo",
         page_from: nil,
         page_to:   nil,
@@ -91,7 +91,7 @@ RSpec.describe Notes::SearchNotes, type: :service do
       end
 
       notes, meta = described_class.call(
-        book_id:   book.id,
+        book:   book,
         query:     nil,
         page_from: nil,
         page_to:   nil,
@@ -106,26 +106,13 @@ RSpec.describe Notes::SearchNotes, type: :service do
       expect(notes.size).to         eq 5
     end
 
-    it '存在しない book_id の場合は ActiveRecord::RecordNotFound を投げる' do
-      expect {
-        described_class.call(
-          book_id:   999_999,
-          query:     nil,
-          page_from: nil,
-          page_to:   nil,
-          page:      1,
-          limit:     10
-        )
-      }.to raise_error(ActiveRecord::RecordNotFound)
-    end
-
     it 'page_from / page_to でページ範囲を絞り込む' do
       note_low = Note.create!(book: book, page: 5,  quote: "low",  memo: "m")
       note_mid = Note.create!(book: book, page: 15, quote: "mid",  memo: "m")
       note_hi  = Note.create!(book: book, page: 25, quote: "high", memo: "m")
 
       notes, meta = described_class.call(
-        book_id:   book.id,
+        book:   book,
         query:     nil,
         page_from: 10,
         page_to:   20,
@@ -142,7 +129,7 @@ RSpec.describe Notes::SearchNotes, type: :service do
     it 'page_from が page_to より大きい場合は BadRequest を投げる' do
       expect {
         described_class.call(
-          book_id:   book.id,
+          book:   book,
           query:     nil,
           page_from: 20,
           page_to:   10,
@@ -155,7 +142,7 @@ RSpec.describe Notes::SearchNotes, type: :service do
     it 'page が整数文字列でない場合は BadRequest を投げる' do
       expect {
         described_class.call(
-          book_id:   book.id,
+          book:   book,
           query:     nil,
           page_from: nil,
           page_to:   nil,
@@ -168,7 +155,7 @@ RSpec.describe Notes::SearchNotes, type: :service do
     it 'page_from / page_to が整数文字列でない場合は BadRequest を投げる' do
       expect {
         described_class.call(
-          book_id:   book.id,
+          book:   book,
           query:     nil,
           page_from: "foo",
           page_to:   "20",
@@ -180,7 +167,7 @@ RSpec.describe Notes::SearchNotes, type: :service do
 
     it 'page <= 0 の場合は 1 に正規化される' do
       notes, meta = described_class.call(
-        book_id:   book.id,
+        book:   book,
         query:     nil,
         page_from: nil,
         page_to:   nil,
@@ -193,7 +180,7 @@ RSpec.describe Notes::SearchNotes, type: :service do
 
     it 'limit が nil のときは DEFAULT_LIMIT になる' do
       notes, meta = described_class.call(
-        book_id:   book.id,
+        book:   book,
         query:     nil,
         page_from: nil,
         page_to:   nil,
@@ -220,7 +207,7 @@ RSpec.describe Notes::SearchNotes, type: :service do
       )
 
       notes, meta = described_class.call(
-        book_id:   book.id,
+        book:   book,
         query:     "foo",
         page_from: nil,
         page_to:   nil,
@@ -245,7 +232,7 @@ RSpec.describe Notes::SearchNotes, type: :service do
       end
 
       notes, meta = described_class.call(
-        book_id:   book.id,
+        book:   book,
         query:     nil,
         page_from: nil,
         page_to:   nil,
@@ -254,21 +241,6 @@ RSpec.describe Notes::SearchNotes, type: :service do
       )
 
       expect(meta[:limit]).to eq Notes::SearchNotes::MAX_LIMIT
-    end
-
-    it 'soft-deleted book の場合は ActiveRecord::RecordNotFound を投げる' do
-      book.update!(deleted_at: Time.current)
-    
-      expect {
-        described_class.call(
-          book_id:   book.id,
-          query:     nil,
-          page_from: nil,
-          page_to:   nil,
-          page:      1,
-          limit:     10
-        )
-      }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
     describe '空白区切り AND 検索' do
@@ -293,7 +265,7 @@ RSpec.describe Notes::SearchNotes, type: :service do
         )
 
         notes, meta = described_class.call(
-          book_id:   book.id,
+          book:  book,
           query:     "ラーメン おすすめ",
           page_from: nil,
           page_to:   nil,
@@ -307,7 +279,7 @@ RSpec.describe Notes::SearchNotes, type: :service do
 
       it 'q="   "（空白のみ）は未指定扱いで全件返す' do
         notes, meta = described_class.call(
-          book_id:   book.id,
+          book:   book,
           query:     "   ",
           page_from: nil,
           page_to:   nil,
@@ -327,7 +299,7 @@ RSpec.describe Notes::SearchNotes, type: :service do
         )
 
         notes, meta = described_class.call(
-          book_id:   book.id,
+          book:   book,
           query:     "ラーメン  おすすめ",  # 連続空白
           page_from: nil,
           page_to:   nil,
@@ -347,7 +319,7 @@ RSpec.describe Notes::SearchNotes, type: :service do
         )
 
         notes, meta = described_class.call(
-          book_id:   book.id,
+          book:   book,
           query:     "ラーメン おすすめ",
           page_from: nil,
           page_to:   nil,


### PR DESCRIPTION
- bookの通常API操作対象を「current_user所有かつalive」の統一
  - book destroyをsoft deleteとして追加
  - Bulk/Searchのbook解決をController入口に統一

- specの追加・整理
  - soft delete後に一覧から除外されること
  - 他人bookを削除できないこと
  - 他人bookでbulk/searchできないこと
  - Service specを確認済みbook前提に整理