### PR TITLE
docs: update API contracts and architecture docs

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,55 +1,114 @@
 # Reading Notes Backend
 
-データ整合性と障害耐性を重視して設計した読書引用管理用 REST API。
-Bearer トークン認証と所有者ベースのデータアクセス制御を実装している。
+データ整合性と障害耐性を重視して設計した読書引用管理用 REST API。  
+Bearer Token 認証と、ログイン中ユーザーごとの所有者ベースのデータアクセス制御を実装しています。
 
+---
 
 ## Production URL
 
 Base URL:
-https://backend-withered-voice-4962.fly.dev
 
-Example:
+```text
+https://backend-withered-voice-4962.fly.dev
+```
+
+Health Check:
 
 ```bash
 curl https://backend-withered-voice-4962.fly.dev/healthz
 ```
 
+---
+
+## Quick Evaluation Route
+
+本番環境で最小限の動作確認を行う場合は、以下の順で確認できます。
+
+1. `GET /healthz`
+2. `POST /api/users`
+3. `POST /api/auth/session`
+4. `GET /api/books` with Bearer Token
+5. `POST /api/books` with Bearer Token
+6. `DELETE /api/books/:id` with Bearer Token
+
+詳細なAPI仕様・レスポンス例は [`docs/40_api/api_overview.md`](docs/40_api/api_overview.md) を参照してください。
+
+---
+
 ## Design Intent
 
-本APIは以下を重視して設計した。
+本APIは以下を重視して設計しています。
 
 - **DB制約によるデータ整合性の保証**
-  - NOT NULL / CHECK / FK を用いてアプリ層の不具合でも破壊的データを防ぐ
-- **例外系の統一**
-  - 400 / 401 / 404 / 422 / 500 を ApplicationController で一元処理
-  - DB制約違反（NotNullViolation, InvalidForeignKey, CheckViolation）は 422 に変換
-  - レスポンス形式 `{ error: { code, message, details? } }` に統一
-- **Bearer トークン認証と所有者スコープ**
-  - ログイン時に発行した raw トークンは返却のみとし、DBには SHA256 digest のみ保存
-  - 全データエンドポイントで `current_user.books` による所有者フィルタリングを実施
+  - `NOT NULL` / `CHECK` / `FK` を用いて、アプリ層の不具合でも破壊的データを防ぐ
+
+- **Bearer Token 認証と所有者スコープ**
+  - ログイン時に発行した raw token はクライアントにのみ返却し、DBには SHA256 digest のみ保存
+  - データ操作APIでは `current_user.books` を起点に所有者境界を担保
+
+- **Controller入口での境界統一**
+  - Book ID を受け取るAPIでは、Controller側で `current_user.books.alive.find(...)` により、認証・所有権・未削除Bookであることを確認
+  - 他ユーザーBook・削除済みBook・存在しないBookは `404 Not Found` として扱い、所有関係を外部に露出しない
+
+- **Controller / Service の責務分離**
+  - ControllerはHTTP境界の確認とレスポンス生成を担当
+  - Service層には確認済みのBookを渡し、Bulk作成やSearchなどの処理本体に責務を集中
+
+- **Bulk作成のトランザクション境界**
+  - Note一括作成では、全件成功 or 全件失敗のトランザクションとして扱う
+  - 一部のNoteがinvalidな場合、DBには1件も作成しない
+  - `details` に `index` と `messages` を返し、どの要素が失敗したかを示す
+
+- **エラーハンドリングの共通化**
+  - `ApplicationController` の `rescue_from` で主要な例外を一元処理
+  - `400` / `401` / `404` / `422` / `500` を統一したレスポンス形式で返す
+  - DB制約違反も `422 Unprocessable Entity` に変換する
+
+- **Book の論理削除**
+  - Book削除時は物理削除ではなく `deleted_at` を更新
+  - 通常の一覧・Notes系APIでは削除済みBookを対象外にする
+
 - **無料サーバーレス構成での実運用再現**
   - Fly.io + Neon による公開環境
   - コールドスタート遅延を含めて説明可能な状態
 
-目的は
-**「壊れないAPIを設計・説明できることの証明」**
-である。
+目的は、**「壊れにくいAPIを設計・実装・説明できることの証明」**です。
+
+---
+
+## Documentation
+
+| ドキュメント | 内容 |
+|-------------|------|
+| [`docs/40_api/api_overview.md`](docs/40_api/api_overview.md) | API仕様・認証・エラー形式・本番確認済みフロー |
+| [`docs/30_architecture/db_constraints.md`](docs/30_architecture/db_constraints.md) | DB制約設計 |
+| [`docs/30_architecture/error_handling.md`](docs/30_architecture/error_handling.md) | 共通エラーハンドリング |
+| [`docs/30_architecture/transaction_boundary.md`](docs/30_architecture/transaction_boundary.md) | Bulk作成のトランザクション境界 |
+| [`docs/30_architecture/service_layer_notes.md`](docs/30_architecture/service_layer_notes.md) | Notes系Service層の責務 |
+| [`docs/30_architecture/notes_destroy_authorization.md`](docs/30_architecture/notes_destroy_authorization.md) | Note削除時の認可境界 |
+| [`docs/20_design/soft_delete_policy.md`](docs/20_design/soft_delete_policy.md) | Book論理削除ポリシー |
+| [`docs/30_architecture/debug_endpoints.md`](docs/30_architecture/debug_endpoints.md) | DB制約エラー確認用の開発専用エンドポイント。`Rails.env.development?` の場合のみroutesに追加 |
+
+---
 
 ## 技術スタック
 
 | 項目 | バージョン |
 |------|-----------|
 | Ruby | 3.2.2 |
-| Rails | 8.0.4 (API モード) |
+| Rails | 8.0.4 API mode |
 | PostgreSQL | 16 |
-| テスト | RSpec |
+| Test | RSpec |
+| Production | Fly.io + Neon |
+
+---
 
 ## DB 設計
 
 ### ER 図
 
-```
+```text
 ┌──────────┐  1:N  ┌──────────┐  1:N  ┌──────────┐
 │  users   ├───────┤  books   ├───────┤  notes   │
 ├──────────┤       ├──────────┤       ├──────────┤
@@ -72,36 +131,37 @@ curl https://backend-withered-voice-4962.fly.dev/healthz
 └──────────────────┘
 ```
 
-### 主な設計ポイント
+詳細なDB制約は [`docs/30_architecture/db_constraints.md`](docs/30_architecture/db_constraints.md) を参照してください。
 
-- **所有者ベースのアクセス**: Book は必ず User に属し、API は `current_user.books` 経由でのみアクセスできる。他ユーザーのデータは参照・操作不可
-- **論理削除**: Book は `deleted_at` による論理削除。Note との参照整合性を保ち、履歴を失わないため
-- **FK 制約（RESTRICT）**: `notes.book_id → books.id` は `ON DELETE RESTRICT`。Note が存在する Book の誤削除を DB レベルで防ぐ
-- **CHECK 制約**: `quote` 最大1000文字、`memo` 最大2000文字、`page >= 1`。アプリのバグや不正入力があっても DB で破壊的データを防ぐ
-- **digest 保存によるトークンの漏えい耐性**: ログイン時に発行する raw トークンはクライアントへの返却のみとし、DB には SHA256 digest のみ保存する。DB が漏えいしても raw トークンへの復元を防ぐ
-- **トークン失効管理**: `expires_at`（発行から30日）と `revoked_at`（明示的なログアウト）の両方で有効性を管理。`AccessToken.active` スコープで一元チェック
+---
 
 ## API エンドポイント
 
-認証が必要なエンドポイントには `Authorization: Bearer <token>` ヘッダが必要。
+認証が必要なエンドポイントには `Authorization: Bearer <token>` ヘッダーが必要です。
 
 | Method | Path | 認証 | 説明 |
 |--------|------|------|------|
-| POST | `/api/auth/session` | 不要 | ログイン（トークン発行） |
-| DELETE | `/api/auth/session` | 必要 | ログアウト（トークン失効） |
-| GET | `/api/books` | 必要 | 自分の Book 一覧取得 |
-| POST | `/api/books` | 必要 | Book 作成 |
-| POST | `/api/books/:book_id/notes` | 必要 | Note 作成 |
-| DELETE | `/api/notes/:id` | 必要 | Note 削除 |
-| POST | `/api/books/:book_id/notes/bulk` | 必要 | Note 一括作成（最大20件） |
-| GET | `/api/books/:book_id/notes_search` | 必要 | Note 検索（キーワード/ページ範囲） |
+| GET | `/healthz` | 不要 | Health Check |
+| POST | `/api/users` | 不要 | ユーザー作成 |
+| POST | `/api/auth/session` | 不要 | ログイン（Token発行） |
+| DELETE | `/api/auth/session` | 必要 | ログアウト（Token失効） |
+| GET | `/api/books` | 必要 | 自分の未削除Book一覧取得 |
+| POST | `/api/books` | 必要 | Book作成 |
+| DELETE | `/api/books/:id` | 必要 | Book論理削除 |
+| POST | `/api/books/:book_id/notes` | 必要 | Note作成 |
+| DELETE | `/api/books/:book_id/notes/:id` | 必要 | Note削除 |
+| POST | `/api/books/:book_id/notes/bulk` | 必要 | Note一括作成 |
+| GET | `/api/books/:book_id/notes_search` | 必要 | Note検索（キーワード / ページ範囲） |
 
-詳細は [`docs/40_api/api_overview.md`](docs/40_api/api_overview.md) を参照。
+詳細は [`docs/40_api/api_overview.md`](docs/40_api/api_overview.md) を参照してください。
+
+---
 
 ## 起動手順
 
 ### Docker Compose で起動
-※ PostgreSQL のポートはホストに公開していません。
+
+PostgreSQL のポートはホストに公開していません。  
 ローカルに PostgreSQL がインストールされていても衝突せず起動できます。
 
 ```bash
@@ -115,53 +175,18 @@ docker compose exec web bin/rails db:prepare
 docker compose exec web bin/rails db:seed
 ```
 
-### 動作確認
+---
 
-> `jq` が必要です。未インストールの場合は `| jq` を省略し、JSON レスポンスから手動でトークンを取得してください。
+## 動作確認
 
-```bash
-# ① テストユーザーを作成する（初回のみ）
-docker compose exec web bin/rails runner \
-  "User.find_or_create_by!(email: 'dev@example.com') { |u| u.password = 'password' }"
+ローカルでAPIを確認する場合は `http://localhost:3000` をBase URLとして実行してください。  
+本番環境で確認する場合は `https://backend-withered-voice-4962.fly.dev` に置き換えて実行できます。
 
-# ② ログイン → TOKEN を環境変数に入れる
-TOKEN=$(curl -s -X POST http://localhost:3000/api/auth/session \
-  -H "Content-Type: application/json" \
-  -d '{"email":"dev@example.com","password":"password"}' \
-  | jq -r '.token')
+詳細なcurl例・レスポンス例は [`docs/40_api/api_overview.md`](docs/40_api/api_overview.md) を参照してください。
 
-echo $TOKEN   # トークンが表示されれば成功
+---
 
-# ③ Book 一覧取得
-curl -s http://localhost:3000/api/books \
-  -H "Authorization: Bearer $TOKEN" | jq
-
-# ④ Book 作成 → BOOK_ID を環境変数に入れる
-BOOK_ID=$(curl -s -X POST http://localhost:3000/api/books \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer $TOKEN" \
-  -d '{"book":{"title":"Test Book","author":"Author"}}' \
-  | jq -r '.id')
-
-echo "Book ID: $BOOK_ID"
-
-# ⑤ Note 一括作成
-curl -s -X POST "http://localhost:3000/api/books/$BOOK_ID/notes/bulk" \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer $TOKEN" \
-  -d '{
-    "notes": [
-      {"page": 1, "quote": "最初の引用文", "memo": "メモ1"},
-      {"page": 2, "quote": "2番目の引用文", "memo": "メモ2"}
-    ]
-  }' | jq
-
-# ⑥ ログアウト（トークン失効）
-curl -s -X DELETE http://localhost:3000/api/auth/session \
-  -H "Authorization: Bearer $TOKEN" | jq
-```
-
-### 停止
+## 停止
 
 ```bash
 # Ctrl+C で停止後
@@ -170,6 +195,8 @@ docker compose down
 # DB も消したい場合
 docker compose down -v
 ```
+
+---
 
 ## テスト
 
@@ -185,125 +212,48 @@ RAILS_ENV=test bin/rails db:prepare
 bundle exec rspec
 ```
 
+---
+
 ## ディレクトリ構成
 
-```
+```text
 backend/
 ├── app/
-│   ├── controllers/api/      # API コントローラ
-│   │   └── auth/             # 認証コントローラ（session）
-│   ├── models/               # ActiveRecord モデル
-│   ├── services/notes/       # ビジネスロジック
-│   └── errors/               # カスタム例外
+│   ├── controllers/api/      # API controllers
+│   │   └── auth/             # Auth controller
+│   ├── models/               # ActiveRecord models
+│   ├── services/notes/       # Business logic
+│   └── errors/               # Custom exceptions
 ├── docs/
-│   ├── 20_design/            # 設計方針
-│   ├── 30_architecture/      # アーキテクチャ設計
-│   └── 40_api/               # API 仕様
+│   ├── 20_design/            # Design policies
+│   ├── 30_architecture/      # Architecture docs
+│   └── 40_api/               # API docs
 ├── spec/
-│   ├── requests/api/         # Request spec
-│   ├── services/notes/       # Service spec
-│   └── models/               # Model spec
+│   ├── requests/api/         # Request specs
+│   ├── requests/auth/        # Authentication request specs
+│   ├── services/notes/       # Service specs
+│   └── models/               # Model specs
 └── db/
-    ├── migrate/              # マイグレーション
-    └── schema.rb             # スキーマ定義
+    ├── migrate/              # Migrations
+    └── schema.rb             # Schema definition
 ```
 
-## 設計ドキュメント
-
-| ドキュメント | 内容 |
-|-------------|------|
-| [`docs/40_api/api_overview.md`](docs/40_api/api_overview.md) | API 仕様（エンドポイント詳細） |
-| [`docs/30_architecture/error_handling.md`](docs/30_architecture/error_handling.md) | エラーハンドリング設計 |
-| [`docs/30_architecture/transaction_boundary.md`](docs/30_architecture/transaction_boundary.md) | トランザクション境界 |
-| [`docs/30_architecture/debug_endpoints.md`](docs/30_architecture/debug_endpoints.md) | デバッグ用エンドポイント（development限定） |
-| [`docs/20_design/soft_delete_policy.md`](docs/20_design/soft_delete_policy.md) | 論理削除ポリシー |
-
-
-## Runtime Performance Characteristics（コールドスタートによる遅延）
-
-### 概要
-
-- **初回アクセス遅延:** 約5秒
-- **2回目以降:** 約200ms
-
-この遅延は、**一定時間アクセスが無かった後の最初のリクエストのみ**発生する。
-
 ---
 
-### 根本原因
+## Runtime Performance Characteristics
 
-本遅延はアプリケーション性能ではなく、
-**サーバーレスインフラのコールドスタート**によるもの。
+本番環境は Fly.io + Neon の無料サーバーレス構成で運用しています。
 
-- **Fly.io のオートストップ**
-  - トラフィックが無いと VM が自動停止する。
-  - 次回アクセス時に VM 起動待ちが発生する。
+一定時間アクセスがない場合、初回リクエストでコールドスタートが発生します。
 
-- **Neon（Serverless Postgres）のコールドスタート**
-  - 初回接続時に DB コンピュートが再開される。
-  - 最初のクエリに数秒の遅延が追加される。
+- 初回アクセス: 約5秒
+- 2回目以降: 約200ms
 
----
+これはアプリケーションコードやSQLの性能問題ではなく、Fly.io VM と Neon compute の再開による遅延です。  
+ポートフォリオ用途では、無料運用のトレードオフとして許容しています。
 
-### 根拠（本番ログ）
-
-**遅いリクエスト**
-
-- Total: 約5.1秒
-- ActiveRecord: 約3.6秒
-- **VM 起動直後に発生**
-
-**通常リクエスト**
-
-- Total: 約218ms
-- ActiveRecord: 約213ms
-
-これにより：
-
-- SQL 自体は本質的に遅くない
-- 遅延は **コールドスタート時のみ**発生
-- アプリケーションコードやクエリ設計は **ボトルネックではない**
-
----
-
-### 追加検証（curl による実測）
+確認例:
 
 ```bash
-# 1回目（コールドスタート）
-time curl -o /dev/null -s https://backend-withered-voice-4962.fly.dev/healthz
-
-# 2回目（ウォーム）
 time curl -o /dev/null -s https://backend-withered-voice-4962.fly.dev/healthz
 ```
----
-
-### なぜ対策を行っていないか
-
-考えられる対策：
-
-- Fly.io マシンの常時起動
-- Neon の有料プラン利用（コールドスタート回避）
-- 定期 keep-alive ping の導入
-
-本プロジェクトでは **意図的に未実施**とした。
-
-理由：
-
-- 本アプリは **ポートフォリオ用途**
-- **完全無料のサーバーレス構成**での運用を前提としている
-- コールドスタート遅延は **仕様上のトレードオフ**であり不具合ではない
-
----
-
-### 結論
-
-観測された遅延は：
-
-- **インフラ起因である**
-- **再現性があり説明可能**
-- **無料サーバーレス運用の範囲では許容可能**
-
-したがって、
-**アプリケーションレベルの最適化は不要**と判断した。
-
----

--- a/backend/docs/20_design/soft_delete_policy.md
+++ b/backend/docs/20_design/soft_delete_policy.md
@@ -1,53 +1,170 @@
 # Soft Delete Policy (Books)
 
-## 方針
-- Book は物理削除しない（DELETE / Book.destroy / delete は提供しない）
-- Book の削除は論理削除とし、`deleted_at` に削除時刻を記録する（NULL 可）
-- 通常の取得（一覧 / 詳細 / 検索）は **削除されていない Book のみ**を対象とする  
-  - 条件：`deleted_at IS NULL`
+## 目的
 
-## alive チェックの責務（原則）
+Book は物理削除せず、`deleted_at` による論理削除として扱う。
 
-- **原則**: Service が存在する場合、Book の alive チェック（`Book.alive.find`）は Service 層で行う。
-- Controller は book_id をそのまま Service に渡し、存在保証・生存保証は Service の責務とする。
+削除済みBookは通常のAPI導線では「存在しないもの」として扱い、  
+Book一覧・Note作成・Bulk作成・Note検索などの対象から除外する。
 
-### 例外: Controller が @book を使用する場合
+---
 
-以下のケースでは、Controller 側で `Book.alive.find` を行ってよい。
+## 基本方針
 
-- **MVP / シンプル CRUD**: Service を作らず Controller + Model で完結する場合
-  （例: `NotesController#create` で `@book.notes.create!` を直接実行）
-- **二重クエリ回避**: Controller が `@book` を使う場合、Service と重複して alive チェックを行わない
+- Book削除時は物理削除せず、`deleted_at` に削除時刻を記録する
+- `deleted_at IS NULL` のBookだけを通常のAPI対象にする
+- 削除済みBookは、通常導線では `404 Not Found` として扱う
+- 物理削除によるcascadeは行わない
+- `default_scope` は使わず、明示的な `alive` scope を使う
 
-詳細なルールは [error_handling.md](../30_architecture/error_handling.md#controller--service-の責務book存在確認aliveの置き場所) を参照。
+---
 
-### 例外的に deleted Book を参照するケース
+## API上の扱い
 
-通常導線では deleted Book は「存在しない扱い」とする。
+削除済みBookは、クライアントから見ると「存在しないリソース」として扱う。
 
-ただし、以下の用途に限り、deleted Book を参照する導線を設ける可能性がある。
+以下の場合は `404 Not Found` を返す。
 
-- 管理用途
-- 復元処理
-- 監査・運用ツール
+- Bookが存在しない
+- Bookが削除済み
+- Bookが他ユーザー所有
 
-これらは通常の API / ユースケースとは分離して扱う。
+レスポンス形式は共通エラー仕様に従う。
 
-## API / ユースケースの扱い
-- `deleted_at` が設定された Book は「存在しない扱い」とする
-  - Book の参照（詳細取得 / 検索）: **404 Not Found**
-  - Note の作成 / 検索: **404 Not Found**
-- 理由：
-  - 削除済みリソースはクライアントから見て「存在しない」のが自然
-  - API の分岐が単純になり、実装と運用が安定する
+```json
+{
+  "error": {
+    "code": "not_found",
+    "message": "Resource not found"
+  }
+}
+```
+
+存在しない場合、削除済みの場合、他ユーザー所有の場合を区別しないことで、  
+リソースの存在有無や所有関係を外部に露出しない。
+
+---
+
+## Controller入口での境界統一
+
+Book ID を受け取るAPIでは、Controller入口で以下を確認する。
+
+- 認証済みユーザーであること
+- ログイン中ユーザーが所有するBookであること
+- 削除済みBookではないこと
+
+実装上は、以下のように取得する。
+
+```ruby
+book = current_user.books.alive.find(params[:book_id])
+```
+
+この時点で、存在確認・所有者境界・未削除Book確認をまとめて行う。
+
+---
+
+## Notes系APIでの責務分離
+
+Notes系APIでは、ControllerがHTTP境界を確認し、Serviceには確認済みのBookを渡す。
+
+```text
+Controller
+→ 認証・所有権・alive確認
+→ current_user.books.alive.find(params[:book_id])
+
+Service
+→ 確認済みBookを前提に処理本体を実行
+```
+
+この方針により、Service内で `Book.find` や `Book.alive.find(book_id)` を再実行しない。
+
+理由は以下。
+
+- Service側で所有者境界を取り違えるリスクを下げる
+- Controller入口でHTTP上の境界を明確にする
+- 同じBook取得の二重クエリを避ける
+- Bulk / Search / Create でBook取得ルールを統一する
+
+---
+
+## 対象API
+
+以下のAPIでは、削除済みBookを対象外にする。
+
+| API | 削除済みBookの扱い |
+|-----|------------------|
+| `GET /api/books` | 一覧に含めない |
+| `DELETE /api/books/:id` | すでに削除済みなら `404 Not Found` |
+| `POST /api/books/:book_id/notes` | `404 Not Found` |
+| `DELETE /api/books/:book_id/notes/:id` | `404 Not Found` |
+| `POST /api/books/:book_id/notes/bulk` | `404 Not Found` |
+| `GET /api/books/:book_id/notes_search` | `404 Not Found` |
+
+---
 
 ## DB / Rails の整合
-- 外部キーは `on_delete: :restrict` を維持する  
-  - `notes.book_id -> books.id (RESTRICT)`
-- Rails の関連は DB の RESTRICT 方針に揃える  
-  - `Book has_many :notes`（`dependent: :destroy` は使用しない）
-  - 物理削除の cascade をアプリ層でも発生させない
-  
-## スコープ方針
-- `default_scope` は使用しない（暗黙条件の漏れ・意図しない副作用を避けるため）
-- 取得は明示的な scope を使う（例：`Book.alive`）
+
+Bookは論理削除するため、通常のAPI削除では物理削除を行わない。
+
+一方で、DBレベルでは参照整合性を守るため、外部キー制約を維持する。
+
+- `books.user_id -> users.id`
+- `notes.book_id -> books.id`
+- `ON DELETE RESTRICT`
+
+Railsの関連でも、物理削除cascadeは使わない。
+
+```ruby
+class Book < ApplicationRecord
+  belongs_to :user
+  has_many :notes
+end
+```
+
+`dependent: :destroy` は使わない。  
+通常の削除は `deleted_at` の更新で表現する。
+
+---
+
+## Scope方針
+
+`default_scope` は使用しない。
+
+理由は、暗黙条件によって以下のリスクがあるため。
+
+- 管理用途や調査用途で削除済みBookを確認しづらくなる
+- クエリ条件が見えにくくなる
+- specやdebug時に意図しない除外が起きる
+
+通常APIでは、明示的に `alive` scope を使う。
+
+```ruby
+scope :alive, -> { where(deleted_at: nil) }
+```
+
+---
+
+## 例外的に削除済みBookを参照するケース
+
+通常のAPIでは、削除済みBookは参照しない。
+
+ただし、将来的に以下の用途では削除済みBookを参照する可能性がある。
+
+- 管理画面
+- 復元処理
+- 監査ログ
+- 運用調査
+
+これらは通常のユーザー向けAPIとは分離して扱う。
+
+---
+
+## まとめ
+
+Bookの削除は `deleted_at` による論理削除とする。
+
+通常APIでは、削除済みBookを「存在しないもの」として扱い、  
+Controller入口で `current_user.books.alive.find(...)` により、  
+所有者境界とalive確認を同時に行う。
+
+Serviceには確認済みBookを渡し、処理本体に責務を集中させる。

--- a/backend/docs/30_architecture/error_handling.md
+++ b/backend/docs/30_architecture/error_handling.md
@@ -1,145 +1,111 @@
-# Error Handling（例外設計・境界）
-
-> Docs Scope（役割）
-> 本ドキュメントは例外設計方針（4xx/5xx 境界・rescue_from 方針）を定義する。
-> API レスポンス形式（errors の型など）の最終定義（SSOT）は `docs/40_api/api_overview.md` とする。
-> 本ドキュメントを含む他の設計文書は、当該仕様を上書きしてはならない。
-
+# Error Handling
 
 ## 目的
-- API のエラーを **「ユーザー入力ミス（4xx）」** と **「サーバ側バグ（5xx）」** に分離し、運用とデバッグの精度を上げる。
-- 特に、Ruby/Rails/gem が投げる `ArgumentError` 等を **誤って 400 に変換してバグを隠す事故**を防ぐ。
+
+本APIでは、例外処理を `ApplicationController` の `rescue_from` に集約し、  
+API全体で一貫したHTTPステータスとJSONレスポンスを返す。
+
+各Controllerに個別の `rescue` を書くのではなく、  
+例外クラスごとの扱いを一箇所で管理することで、エラー処理のばらつきを防ぐ。
 
 ---
 
-## Context（Why this rule exists）
+## なぜ `rescue_from` で統一するのか
 
-- Notes Bulk / Search の request spec 作成中、**4xx（入力エラー）と 5xx（バグ）の境界が曖昧になり設計が破綻**
-- `ArgumentError` を 400 に変換すると、**本来 500 として検知すべきバグまで 4xx に埋もれる**と判明
-- 以後、**「意図して投げた例外のみを 4xx、その他は 5xx」**に固定
+Rails の `rescue_from` は、Controller内で発生した特定の例外を捕捉し、  
+指定したメソッドやProcで処理するための仕組みである。
 
----
+Rails Guides でも、`rescue_from` は特定の例外を捕捉して別の処理を行う方法として説明されており、  
+そのController全体およびサブクラスに対して適用できる。  
+また、Rails APIでは `ActionController::Rescue` がControllerに `rescue_from` を提供し、設定された例外を処理する役割を持つと説明されている。
 
-## 基本方針（結論）
+本APIではこの仕組みを `ApplicationController` に集約し、  
+例外をHTTPステータスと共通JSONレスポンスに変換している。
 
-### 1) 400 は「アプリが意図して投げた例外」だけにする
-- 400 を返すのは **アプリ固有の例外クラス**に限定する。
-- Ruby/Rails/gem の例外を広く rescue して 400 に落とさない。
+これにより、以下を実現する。
 
-### 2) 500 は「想定外の例外（= バグ）」として扱う
-- 想定外例外は 500 を返し、ログ・監視で検知できる状態にする。
-- 本番では `StandardError` を 500 に変換し、スタックトレースをログに残す。
+- Controllerごとのエラーレスポンス形式のばらつきを防ぐ
+- `400` / `401` / `404` / `422` / `500` の対応を一箇所で管理する
+- Controller本体を正常系の処理に集中させる
+- Rails標準例外をAPI仕様に合わせて変換する
+- 想定外エラーを誤ってクライアントエラーに落とさず、バグとして検知する
 
----
+つまり、`rescue_from` による統一は、単なる例外処理の共通化ではなく、  
+**API全体の失敗時の契約を一箇所で管理するための設計**である。
 
-## なぜ `rescue_from ArgumentError` がダメか
-`ArgumentError` は Ruby 標準の一般例外で、次のような「入力ミス」と「バグ」の両方で発生しうる：
-
-- Ruby 標準ライブラリ（`Integer()`, `Date.parse`, `URI.parse`, `Regexp.new` など）
-- Rails 内部（`permit` の誤用、クエリ組み立ての誤用など）
-- 外部 gem（バージョン差で例外クラスが変わることもある）
-
-そのため `rescue_from ArgumentError -> 400` を置くと、
-**本来は 500 で検知すべきバグが 400 になって静かに埋もれる**。
+参考:
+- Rails API: [`ActiveSupport::Rescuable#rescue_from`](https://api.rubyonrails.org/classes/ActiveSupport/Rescuable/ClassMethods.html#method-i-rescue_from)
+- Rails API: [`ActionController::Rescue`](https://api.rubyonrails.org/classes/ActionController/Rescue.html)
 
 ---
 
-## 例外クラス設計（最小）
+## `rescue_from` による一元化
 
-### アプリ固有の 400 系例外
-- `ApplicationErrors::BadRequest < StandardError`
+各Controllerでは、原則として個別に `rescue` を書かない。
 
-必要になったらサブクラスを増やす（例：`InvalidParameter`, `InvalidNotesPayload` など）。
-ただし最初は増やさず、まず「境界を切る」ことを優先する。
+例外は `ApplicationController` でまとめて捕捉し、  
+HTTPステータスとJSONレスポンスに変換する。
 
----
+```ruby
+class ApplicationController < ActionController::API
+  rescue_from ApplicationErrors::BadRequest, with: :render_bad_request
+  rescue_from ActionController::ParameterMissing, with: :render_bad_request
+  rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
+  rescue_from ActiveRecord::RecordInvalid, with: :render_unprocessable_entity
+  rescue_from ActiveRecord::RecordNotDestroyed, with: :render_unprocessable_entity
+  rescue_from Notes::BulkCreate::BulkInvalid, with: :render_bulk_invalid
+end
+```
 
-## rescue_from の探索順と「宣言順ルール」
+共通レスポンス例:
 
-Rails の `rescue_from` は **ハンドラが継承され**、例外発生時に次の順で探索される：
-
-- **右 → 左**
-- **下 → 上**
-- **親クラス方向へ（hierarchy を遡る）**
-
-つまり、**最後に登録された handler が優先されやすい（後勝ち）**。
-
-そのため本プロジェクトでは、意図しない例外の握りつぶしを避けるために  
-**「より具体的な例外を後に書く」**ことをルールとする。
-
-例：`StandardError` は production の **最終受け皿**として使うため、  
-4xx/422 の例外より **先に宣言しない**（食われる事故防止）。
-
-参考（公式）：
-- ActionController::Rescue `rescue_from` API  
-  https://api.rubyonrails.org/v7.0.7/classes/ActiveSupport/Rescuable/ClassMethods.html
-
----
-
-## Controller / Service の責務：Book存在確認（alive）の置き場所
-
-> **Note**: 本セクションは [soft_delete_policy.md](../20_design/soft_delete_policy.md#alive-チェックの責務原則) の例外規定を詳述したものです。
-
-### 結論
-- `Notes::BulkCreate` のように **Service が `Book.alive.find(book_id)` を行う場合**、  
-  Controller 側で同じ存在確認（`before_action :set_book`）を **重ねない**。
-- 同一リクエストで **同じBook取得が2回走る（二重クエリ）**のを防ぐため。
-
-### ルール
-- Controller が `@book` を使うなら `set_book` は置いてよい（例：createで `@book.notes.create!` を呼ぶ場合）
-- Controller が `@book` を使わないなら `set_book` は置かない（存在確認は Service に寄せる）
-
-### 実例
-- ✅ OK: `Api::NotesController#create`
-  - Controller が `@book.notes.create!` を実行するので `set_book` が必要
-- ✅ OK: `Api::NotesBulkController#create`
-  - Book存在確認は `Notes::BulkCreate` 側で実施するため `set_book` は不要（削除済み）
-
-## rescue_from ルール（ApplicationController）
-
-### 4xx（意図した失敗）
-- `ApplicationErrors::BadRequest` -> 400
-- `ActionController::ParameterMissing` -> 400
-- `ActiveRecord::RecordNotFound` -> 404
-- `ActiveRecord::RecordInvalid` / `RecordNotDestroyed` -> 422
-- `Notes::BulkCreate::BulkInvalid` -> 422（Bulk専用）
-
-### 422（DB制約違反）
-- `ActiveRecord::NotNullViolation` -> 422
-- `ActiveRecord::InvalidForeignKey` -> 422
-- `ActiveRecord::RecordNotUnique` -> 422
-- `ActiveRecord::CheckViolation` -> 422（`defined?` ガード付き）
-
-レスポンス: `{ "errors": ["DB constraint violated"] }`（固定メッセージ）
-
-### 5xx（想定外 = バグ）
-- `StandardError` -> 500（production のみ）
-
-### 禁止
-- `ArgumentError` を rescue_from して 400 に落とすことは禁止
-  （理由：バグまで 400 に変換して検知不能になる）
-
----
-
-## Service / Controller から例外を投げる時のルール
-
-### 400 にしたい時
-- `raise ApplicationErrors::BadRequest, "..."` を使う  
-  もしくは将来の拡張で `InvalidParameter` 等のサブクラスを使う。
-
-### バグの可能性がある時
-- Ruby/Rails/gem の例外を握りつぶして 400 にしない。
-- 例外をそのまま上げて 500 にして、ログで検知できる状態にする。
-
----
-
-## エラーレスポンス形式（API 共通）
-- 共通: すべてのエラーレスポンスは `{ errors: ... }` 形式を持つ。
-- デフォルト型: `errors: string[]`
-- 例外: BulkCreate の 422 のみ
-  `errors: Array<{ index: number, messages: string[] }>`
-- errors 形式の最終決定権（SSOT）は`docs/40_api/api_overview.md` とする。本ドキュメントを含む他の設計文書は、当該仕様を上書きしてはならない。
-
-例：
 ```json
-{ "errors": ["page must be an integer"] }
+{
+  "error": {
+    "code": "not_found",
+    "message": "Resource not found"
+  }
+}
+```
+
+---
+
+## 例外とステータスコードの対応
+
+| Exception | Status | Meaning |
+|----------|--------|---------|
+| `ApplicationErrors::BadRequest` | 400 | アプリが意図して検出した不正リクエスト |
+| `ActionController::ParameterMissing` | 400 | 必須パラメータ不足 |
+| `ActiveRecord::RecordNotFound` | 404 | 対象リソースが存在しない、またはアクセス可能範囲に存在しない |
+| `ActiveRecord::RecordInvalid` | 422 | モデルバリデーション失敗 |
+| `ActiveRecord::RecordNotDestroyed` | 422 | 削除処理失敗 |
+| `Notes::BulkCreate::BulkInvalid` | 422 | Bulk Createの入力行単位バリデーション失敗 |
+| DB制約違反 | 422 | DBレベルの整合性違反 |
+| `StandardError` | 500 | 想定外エラー。本番環境でのみ最終受け皿として扱う |
+
+---
+
+## 4xx / 5xx の境界
+
+本APIでは、`4xx` と `5xx` を以下の基準で分ける。
+
+- `4xx`
+  - クライアントのリクエスト内容に問題がある
+  - アプリ側が意図して検出した失敗
+  - 例: 必須パラメータ不足、存在しないリソース、validation失敗
+
+- `5xx`
+  - サーバ側の想定外エラー
+  - 実装バグや未考慮ケースとして検知すべき失敗
+
+特に、Ruby / Rails / gem の一般例外を安易に `400 Bad Request` に変換しない。  
+たとえば `ArgumentError` は入力ミスだけでなく実装バグでも発生するため、  
+一律で `400` に落とすと、本来検知すべきバグがクライアントエラーに埋もれる。
+
+そのため、`400` にしたい場合は、入力検証の段階でアプリ固有例外を明示的に投げる。
+
+```ruby
+raise ApplicationErrors::BadRequest, "Bad request"
+```
+
+---

--- a/backend/docs/30_architecture/invariants.md
+++ b/backend/docs/30_architecture/invariants.md
@@ -1,169 +1,442 @@
-# Invariants (不変条件) – Notes Domain
+# Invariants
 
-本アプリの品質を支える「守るべき前提条件・壊れてはならない状態」の定義。
+## 目的
 
-ユースケース単位のロジックよりも長寿命であり、
-データ整合性・トランザクション境界・API 一貫性を保証する。
+本ドキュメントは、Reading Notes Backend API における「壊れてはならない前提条件」を定義する。
 
-本ドキュメントの内容は **DB 制約・Model validation と常に一致する必要がある**。
+不変条件は、個別ユースケースよりも長寿命な設計ルールであり、  
+DB制約・Model validation・Controller境界・Service処理・APIレスポンスの整合性を支える。
 
----
-
-# 1. モデル不変条件（Model-Level Invariants）
-
-## (0) Book.title は必須である
-- `NULL` 不可（DB NOT NULL 制約: `20260219104121_make_books_title_not_null.rb`）
-- 空文字は許容しない（Model: `validates :title, presence: true`）
-
-**Why**
-書籍タイトルは Book を識別する最低限の情報であり、省略を許可しない。
+APIレスポンス形式の最終定義は [`docs/40_api/api_overview.md`](../40_api/api_overview.md) を参照する。  
+DB制約の詳細は [`docs/30_architecture/db_constraints.md`](./db_constraints.md) を参照する。
 
 ---
 
-## (1) Note は必ず Book に属する
-- `note.book_id` は **NULL 不可**
-- 存在しない `book_id` を参照しない（FK 制約）
+## 1. Model-Level Invariants
 
-**Why**
-整理の単位が Book であるため、孤児 Note を許可しない。
-DB レベルで整合性を保証する。
+### 1.1 Book title is required
 
----
+Book は必ず `title` を持つ。
 
-## (2) quote は必須である
-- `NULL` 不可
+- `books.title` は `NULL` 不可
 - 空文字は許容しない
-- **最大 1000 文字**（DB CHECK 制約）
+- Model validation でも `presence: true` を確認する
 
 **Why**
-引用が存在しない Note は意味を持たない。
-過剰な長文による DB 汚染を防ぐ。
+
+Book title は書籍を識別する最低限の情報であり、省略を許可しない。
 
 ---
 
-## (3) page は必須であり 1 以上の整数
-- `NULL` 不可（DB NOT NULL）
-- **必ず `>= 1`**（DB CHECK 制約）
+### 1.2 Book belongs to User
+
+Book は必ず User に属する。
+
+- `books.user_id` は `NULL` 不可
+- `books.user_id` は `users.id` への外部キー
+- Book取得はログイン中ユーザーの所有範囲から行う
 
 **Why**
-引用位置は Note の基本属性であり必須情報。
-不正値（0・負数）を DB に保存させない。
+
+Book はユーザーごとのデータ境界であり、所有者を持たないBookを許可しない。
 
 ---
 
-## (4) memo は任意だが上限がある
+### 1.3 AccessToken belongs to User
+
+AccessToken は必ず User に属する。
+
+- `access_tokens.user_id` は `NULL` 不可
+- `access_tokens.user_id` は `users.id` への外部キー
+- `token_digest` は `NULL` 不可かつ一意
+- raw token はDBに保存しない
+- token は `expires_at` と `revoked_at` により有効性を判断する
+
+**Why**
+
+Bearer Token 認証では、tokenの漏えい耐性と失効管理が必要になる。  
+DBには raw token ではなく digest のみを保存することで、DB漏えい時のリスクを下げる。
+
+---
+
+### 1.4 Note belongs to Book
+
+Note は必ず Book に属する。
+
+- `notes.book_id` は `NULL` 不可
+- `notes.book_id` は `books.id` への外部キー
+- 存在しないBookを参照するNoteは保存できない
+
+**Why**
+
+Note はBookに紐づく引用メモであり、孤立したNoteを許可しない。
+
+---
+
+### 1.5 Note page is required and must be greater than or equal to 1
+
+Note の `page` は必須であり、1以上である。
+
+- `notes.page` は `NULL` 不可
+- `page >= 1`
+- DB CHECK制約とModel validationで保証する
+
+**Why**
+
+引用位置はNoteの基本属性であり、0や負数のページを保存させない。
+
+---
+
+### 1.6 Note quote is required
+
+Note の `quote` は必須である。
+
+- `notes.quote` は `NULL` 不可
+- 空文字は許容しない
+- 最大1000文字
+
+**Why**
+
+引用文が存在しないNoteは、読書引用メモとして意味を持たない。  
+また、過剰な長文によるDB肥大化を防ぐ。
+
+---
+
+### 1.7 Note memo is optional but length-limited
+
+Note の `memo` は任意である。
+
 - `NULL` 許容
-- **最大 2000 文字**（DB CHECK 制約）
+- 最大2000文字
 
 **Why**
-補足情報として任意入力を許可しつつ、
-無制限入力による肥大化を防ぐ。
+
+補足メモは任意入力として許可しつつ、無制限入力による肥大化を防ぐ。
 
 ---
 
-## (5) Note の保存は常にアトミック
-- 途中状態（部分更新・不完全保存）は存在しない
-- 永続化はトランザクション境界内で完結する
+## 2. Ownership and Soft Delete Invariants
+
+### 2.1 User can access only own Books
+
+Book / Note 関連APIでは、ログイン中ユーザーが所有するBookだけを対象にする。
+
+Book ID を受け取るAPIでは、Controller入口で以下を確認する。
+
+```ruby
+current_user.books.alive.find(params[:book_id])
+```
+
+これにより、以下を同時に確認する。
+
+- 認証済みユーザーであること
+- ログイン中ユーザーが所有するBookであること
+- Bookが削除済みではないこと
 
 **Why**
-「引用 + メモ」は不可分の単位であり、
-整合性が崩れると意味を失う。
+
+所有者境界をController入口で統一することで、他ユーザーのBook / Noteを参照・操作できないようにする。
 
 ---
 
----
+### 2.2 Deleted Book is treated as not found
 
-# 2. API 不変条件（API-Level Invariants）
+`deleted_at` が設定されたBookは、通常APIでは存在しないものとして扱う。
 
-Bulk Create Notes を中心とした API 振る舞いの保証。
+以下の場合はすべて `404 Not Found` を返す。
 
----
-
-## (1) 1リクエスト = 1トランザクション
-- Service Layer 内で `ActiveRecord::Base.transaction` を使用
-- トランザクション境界は **notes の insert 全体**
-
-**Why**
-atomicity（不可分性）を保証するため。
-
----
-
-## (2) 全件成功 or 全件失敗（All-or-Nothing）
-- 1件でも validation / DB エラーがあれば **全ロールバック**
-- DB に中途半端な保存状態は残らない
-
-**Why**
-UX とデータ整合性の両方を守る最重要条件。
-
----
-
-## (3) エラーは失敗位置を特定可能
-Bulk API の 422 は以下構造：
+- Bookが存在しない
+- Bookが削除済み
+- Bookが他ユーザー所有
 
 ```json
 {
-  "errors": [
-    { "index": 0, "messages": ["page must be greater than or equal to 1"] }
-  ]
+  "error": {
+    "code": "not_found",
+    "message": "Resource not found"
+  }
 }
 ```
 
 **Why**
-部分成功を禁止しつつ、
-ユーザーが修正可能な情報を返す必要がある。
+
+存在しない場合、削除済みの場合、他ユーザー所有の場合を区別しないことで、  
+リソースの存在有無や所有関係を外部に露出しない。
 
 ---
 
-## (4) 二重送信でも破壊的副作用を起こさない
-- 同一リクエストが複数回送信されてもクラッシュしない
-- 完全な idempotency は MVP 範囲外
+### 2.3 Book deletion is logical deletion
+
+Book削除は物理削除ではなく、`deleted_at` の更新で表現する。
+
+- `DELETE /api/books/:id` は `deleted_at` を更新する
+- `GET /api/books` は削除済みBookを返さない
+- Notes系APIは削除済みBookを対象にしない
+- 物理削除によるcascadeは行わない
 
 **Why**
-実運用の「保存ボタン連打」に耐える最低限の安全性。
+
+Book削除後も参照整合性を保ち、必要に応じて将来的な復元・監査・運用調査に対応できる余地を残す。
 
 ---
 
----
+## 3. Bulk Create Invariants
 
-# 3. 検索（SearchNotes）の不変条件
+### 3.1 One request is one transaction
 
-## (1) 検索対象は常に Book 内に限定
-- `WHERE notes.book_id = ?` は常に適用
+`POST /api/books/:book_id/notes/bulk` は、1 HTTP request を1つの論理的な書き込み単位として扱う。
 
-## (2) ページ範囲検索は閉区間
-例：page_from=10, page_to=20 → 10〜20 をすべて含む
-
-## (3) 結果順序は常に created_at DESC
-- 並び順は必ず安定
-- UI 表示順と一致
+- Bulk作成処理は transaction 内で実行する
+- transaction boundary は notes の一括insert全体
 
 **Why**
-読書履歴は「新 → 旧」で確認されるため。
+
+複数Noteの一括保存では、途中まで保存された状態を許容しないため。
 
 ---
 
-# 4. 将来拡張を壊さないための不変条件
+### 3.2 All-or-nothing
 
-## (1) Note の意味は「引用の最小単位」のまま固定
-- タグ・章などは外部テーブルで表現
-- Note 自体の責務は増やさない
+Bulk Create は全件成功または全件失敗のどちらかである。
 
-## (2) Book は Note の最小グループ境界
-- multi-user / 共有機能追加後も境界は維持
+- すべてvalidな場合のみ保存する
+- 1件でもinvalidなNoteがあれば全件rollbackする
+- 部分成功は禁止する
 
-## (3) ビジネスロジックは Service 層に配置
-- Model へ過剰な責務集中を防ぐ
-- トランザクション制御は Service が担う
+```text
+all notes valid
+→ 201 Created
+→ all notes are saved
+
+one or more notes invalid
+→ 422 Unprocessable Entity
+→ no notes are saved
+```
+
+**Why**
+
+連続メモ入力では、一部だけ保存される状態はユーザー体験とデータ整合性の両方を壊す。
 
 ---
 
-# 結論
+### 3.3 Bulk error identifies failed input index
 
-この Invariants により保証される：
+Bulk Create の `422 Unprocessable Entity` では、どの入力行がinvalidだったかを `details` に含める。
 
-- DB 制約と完全一致したモデル整合性
-- Bulk Create の厳密なトランザクション保証
-- 検索結果の順序安定性
-- 将来拡張でも壊れない責務分離
+```json
+{
+  "error": {
+    "code": "unprocessable_entity",
+    "message": "Validation failed",
+    "details": [
+      {
+        "index": 1,
+        "messages": [
+          "Quote can't be blank",
+          "Page must be greater than or equal to 1"
+        ]
+      }
+    ]
+  }
+}
+```
 
-本ドキュメントは Notes ドメインの SSOT（Single Source of Truth）として扱う。
+**Why**
+
+部分成功を禁止しつつ、クライアント側ではどの入力行を修正すべきか判断できる必要がある。
+
+---
+
+## 4. Search Invariants
+
+### 4.1 Search target is limited to confirmed Book
+
+`GET /api/books/:book_id/notes_search` は、Controller入口で確認済みのBookに紐づくNoteだけを検索対象にする。
+
+```ruby
+book = current_user.books.alive.find(params[:book_id])
+```
+
+検索対象は常に以下に限定する。
+
+- ログイン中ユーザーが所有するBook
+- 削除済みではないBook
+- 指定Bookに紐づくNote
+
+**Why**
+
+検索APIでも、所有者境界とsoft delete境界を必ず維持するため。
+
+---
+
+### 4.2 Page range search is inclusive
+
+`page_from` / `page_to` によるページ範囲検索は閉区間である。
+
+```text
+page_from=10, page_to=20
+→ page >= 10 AND page <= 20
+```
+
+**Why**
+
+ユーザーが指定した範囲の開始ページと終了ページを含める方が自然である。
+
+---
+
+### 4.3 Search result order is stable
+
+検索結果は常に `created_at DESC` で返す。
+
+```ruby
+order(created_at: :desc)
+```
+
+**Why**
+
+読書メモは新しく追加したものから確認することが多く、UI表示順とAPIレスポンス順を一致させるため。
+
+---
+
+### 4.4 Empty result is not an error
+
+検索条件に一致するNoteが存在しない場合でも、`200 OK` を返す。
+
+```json
+{
+  "notes": [],
+  "meta": {
+    "total_count": 0,
+    "page": 1,
+    "limit": 10,
+    "total_pages": 0
+  }
+}
+```
+
+**Why**
+
+検索結果が0件であることは正常な検索結果であり、APIエラーではないため。
+
+---
+
+## 5. Error Handling Invariants
+
+### 5.1 Error response shape is unified
+
+エラーレスポンスは、原則として以下の形式に統一する。
+
+```json
+{
+  "error": {
+    "code": "error_code",
+    "message": "error message"
+  }
+}
+```
+
+詳細が必要な場合のみ `details` を含める。
+
+```json
+{
+  "error": {
+    "code": "unprocessable_entity",
+    "message": "Validation failed",
+    "details": [
+      "Title can't be blank"
+    ]
+  }
+}
+```
+
+**Why**
+
+API全体でエラー形式を統一することで、クライアント側のエラー処理を単純にする。
+
+---
+
+### 5.2 4xx and 5xx are separated
+
+本APIでは、4xxと5xxを以下の基準で分ける。
+
+- 4xx
+  - クライアントのリクエスト内容に問題がある
+  - アプリ側が意図して検出した失敗
+
+- 5xx
+  - サーバ側の想定外エラー
+  - 実装バグや未考慮ケースとして検知すべき失敗
+
+**Why**
+
+入力エラーとサーバ側バグを混同すると、運用時の調査・デバッグが難しくなるため。
+
+---
+
+## 6. Responsibility Invariants
+
+### 6.1 Controller owns HTTP boundary
+
+Controller はHTTP境界の処理を担当する。
+
+- 認証
+- 所有者境界
+- alive Book確認
+- request parameterの構造確認
+- response rendering
+
+**Why**
+
+HTTPリクエストに依存する責務をControllerに集約することで、Serviceの責務を処理本体に集中させる。
+
+---
+
+### 6.2 Service owns use case processing
+
+Service は処理本体を担当する。
+
+- Bulk Create の一括作成
+- Bulk Create のtransaction boundary
+- Search条件の適用
+- 必要なドメイン処理
+
+Serviceには、Controllerで確認済みのBookを渡す。
+
+**Why**
+
+Controllerで境界を確定し、Serviceでは確認済み入力を前提に処理本体へ集中するため。
+
+---
+
+## 7. Future Extension Invariants
+
+### 7.1 Note remains the minimum quote unit
+
+Note は「引用メモの最小単位」として扱う。
+
+タグ・章・カテゴリなどは、将来的に外部テーブルで表現する。  
+Note自体に過剰な責務を持たせない。
+
+---
+
+### 7.2 Book remains the group boundary for Notes
+
+Book はNoteの最小グループ境界である。
+
+共有機能や共同編集機能を追加する場合でも、NoteはBookを通じて管理する。
+
+---
+
+## まとめ
+
+本APIでは、以下の不変条件を守る。
+
+- Book / Note / AccessToken のDB整合性
+- ログイン中ユーザーごとの所有者境界
+- Bookの論理削除
+- Bulk Create の all-or-nothing
+- Search対象のBook内限定
+- 共通エラーレスポンス形式
+- Controller / Service の責務分離
+
+これらにより、認証・所有権・DB制約・トランザクション・検索結果の一貫性を保証する。

--- a/backend/docs/30_architecture/notes_destroy_authorization.md
+++ b/backend/docs/30_architecture/notes_destroy_authorization.md
@@ -1,19 +1,80 @@
-# notes#destroy 認可メモ
+# Notes Destroy Authorization
 
-## 現在の問題
-- `notes#destroy` で `Note.find(params[:id])` を使っている
-- このままだと、current_user の所有範囲外の note に触れられる可能性がある
+## 目的
 
-## 認可の方向性
-- destroy の対象は、current_user が所有している note の中の1件にする
-- 所有関係は `user -> books -> notes` で辿る
-- グローバルな `Note` 全体から取得しない
+`DELETE /api/books/:book_id/notes/:id` では、ログイン中ユーザーが所有する未削除Bookに紐づくNoteだけを削除対象にする。
+
+Noteをグローバルな `Note.find(params[:id])` で取得すると、他ユーザーのNote IDを直接指定された場合に、所有者境界を越えて操作できる可能性がある。  
+そのため、本APIではBookの所有者境界を先に確認し、そのBookに紐づくNoteだけを削除対象にする。
+
+---
+
+## 認可方針
+
+Note削除では、以下の順序で対象リソースを取得する。
+
+1. Bearer Token によりログイン中ユーザーを特定する
+2. `current_user.books.alive.find(params[:book_id])` により、ログイン中ユーザーが所有する未削除Bookだけを取得する
+3. 取得済みBookに紐づくNoteから `params[:id]` のNoteを取得する
+4. 見つかったNoteのみ削除する
+
+この方針により、Note単体をグローバルに検索しない。
+
+---
+
+## 境界条件
+
+以下の場合は `404 Not Found` として扱う。
+
+- Bookが存在しない
+- Bookが削除済み
+- Bookが他ユーザー所有
+- Noteが存在しない
+- Noteが指定Bookに紐づいていない
+
+レスポンスは共通エラー形式に従う。
+
+```json
+{
+  "error": {
+    "code": "not_found",
+    "message": "Resource not found"
+  }
+}
+```
+
+存在しない場合と所有権がない場合を区別しないことで、リソースの存在有無や所有関係を外部に露出しない。
+
+---
 
 ## 期待する動作
-- 自分の note は削除できる
-- 他人の note は削除できない
-- current_user の所有範囲で見つからなければ失敗として扱う
 
-## 次にやること
-- 今の Rails の関連の中で、所有者スコープ付きの note 集合をどう表現するか決める
-- 実装後、user A / user B で確認する
+- 自分のBookに紐づくNoteは削除できる
+- 他ユーザーのBookに紐づくNoteは削除できない
+- 他ユーザーのBook IDを指定した場合は `404 Not Found`
+- 自分のBook IDを指定しても、そのBookに存在しないNote IDなら `404 Not Found`
+- 削除済みBookに対するNote削除は `404 Not Found`
+
+---
+
+## 実装上の要点
+
+Notes系APIでは、Controller入口でBookの境界を確定する。
+
+```ruby
+book = current_user.books.alive.find(params[:book_id])
+note = book.notes.find(params[:id])
+note.destroy!
+```
+
+この構成により、所有者境界は `current_user.books` で担保し、Note削除対象は取得済みBookの配下に限定する。
+
+---
+
+## 確認すべきspec
+
+- `deletes own note`
+- `returns 404 when book belongs to another user`
+- `returns 404 when note belongs to another book`
+- `returns 404 when book is soft-deleted`
+- `returns 401 without Bearer token`

--- a/backend/docs/40_api/api_contracts/bulk_create_notes.md
+++ b/backend/docs/40_api/api_contracts/bulk_create_notes.md
@@ -1,214 +1,337 @@
 # Bulk Create Notes API Contract
 
-###　ノート一括作成（Bulk Create）
+## 0. Purpose
 
-##　0. Purpose（この API の存在理由）
+`POST /api/books/:book_id/notes/bulk` は、1つのBookに対して複数のNoteを一括作成するためのAPIである。
 
-読書中の「連続メモ入力」を効率化するため、複数の Note を
-1リクエストで原子的（atomic）に保存することを目的とする。
+読書中の連続メモ入力では、複数の引用メモをまとめて保存したいケースがある。  
+このAPIでは、1リクエストを1つの論理的な書き込み単位として扱い、全件成功または全件失敗のどちらかに統一する。
 
-ユーザー体験（UX）上も、
-一部だけ保存される中途半端な状態は許容できない。
-
----
-
-## 1. Flow（連続メモ入力の流れ）
-
-- ユーザーは「連続メモモード」を開く
-- 縦に並んだ入力行（page / quote / memo）に次々入力していく
-- 入力済みの行は一旦フロント側の下書きリストに保持される
-- 最後に「◯件まとめて保存」ボタンを押す
-- フロントは下書きリストを `notes` 配列として 1リクエストで送信する
-- サーバ側では全件が valid のときだけ保存し、
-  1件でも invalid な場合は全件ロールバックし、エラー情報を返す
-
----
-## 2. Constraints（制約）
-
-- 1リクエストあたりの `notes` の最大件数: 20件
-- `notes` は必須の配列（空配列はエラー）
-
+部分的に保存される中途半端な状態は許容しない。
 
 ---
 
-## 3. Validation Rules（入力のルール）
+## 1. Endpoint
 
-- `page`:
-  - null 許容
-  - null でない場合は 1 以上の整数
-- `quote`:
-  - 必須
-  - 空文字・空白のみは NG
-  - 最大 1000 文字
-- `memo`:
-  - 任意（null OK）
-  - 最大 2000 文字
-- `notes` 自体が配列でない or 空配列なら 400 Bad Request
-
+```http
+POST /api/books/:book_id/notes/bulk
+```
 
 ---
 
-## 4. Endpoint
-**POST /api/books/:book_id/notes/bulk**
+## 2. Authentication
 
+このAPIは Bearer Token 認証を必要とする。
+
+```http
+Authorization: Bearer <token>
+```
+
+未認証、無効Token、期限切れToken、revoked Token の場合は `401 Unauthorized` を返す。
+
+```json
+{
+  "error": {
+    "code": "unauthorized",
+    "message": "Authentication required"
+  }
+}
+```
 
 ---
 
-## 5. Request / Response
+## 3. Ownership Boundary
 
-## Request Body
+このAPIでは、Controller側で以下の条件を満たすBookのみを対象にする。
+
+- ログイン中ユーザーが所有していること
+- `deleted_at` が `nil` であること
+
+実装上は、Book取得を以下の境界で行う。
+
+```ruby
+current_user.books.alive.find(params[:book_id])
+```
+
+そのため、以下の場合はすべて `404 Not Found` として扱う。
+
+- Bookが存在しない
+- Bookが削除済み
+- Bookが他ユーザー所有
+
+```json
+{
+  "error": {
+    "code": "not_found",
+    "message": "Resource not found"
+  }
+}
+```
+
+これは、リソースの存在有無や所有関係を外部に露出しないためである。
+
+---
+
+## 4. Request
+
+### Path Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `book_id` | integer | Yes | 対象BookのID |
+
+### Request Body
+
 ```json
 {
   "notes": [
-    { "page": 12, "quote": "....", "memo": "..." },
-    { "page": 13, "quote": "....", "memo": null }
-  ]
-}
-
-```
-
-## Success (201):
-
-```json
-{
-  "notes": [
-    { "id": 101, "page": 12, "quote": "...", "memo": "...", "created_at": "..." },
-    { "id": 102, "page": 13, "quote": "...", "memo": null, "created_at": "..." }
-  ],
-  "meta": { "created_count": 2 }
-}
-```
-
-#### エラー
-- notes が空 / 配列でない … 400 Bad Request
-  - 例: {"errors": ["notes must be a non-empty array"]}
-- 要素数が上限を超える … 400 Bad Request
-  - 例: {"errors": ["too many notes (max 20)"]}
-- 要素の一部でバリデーションエラー … 422 Unprocessable Entity
-  - 形式は共通仕様「1.1 Bulk API 固有のエラー形式」を参照
-- 本が存在しない場合 … 404 Not Found
-
-## Failure (422, 1件でも NG):
-
-```json
-{
-  "errors": [
-    { "index": 0, "messages": ["page must be greater than 0"] },
-    { "index": 2, "messages": ["quote can't be blank"] }
-  ]
-}
-```
-
-
-## 6. エラー仕様
-
-このセクションでは、Bulk Create API 固有のエラー仕様のみを定義する。  
-共通エラー仕様（400 / 404 / 422 / 500 の一般的な意味・レスポンス形式）は  
-**api_overview.md** を参照とし、本ファイルでは **差分のみ** を記述する。
-
----
-
-## 6.1. Bulk Create のステータスコード運用
-
-### 400 Bad Request（Bulk Create 固有ルール）
-
-以下の Bulk Create 固有条件のとき 400 を返す：
-
-- `notes` が **配列でない**
-- `notes` が **空配列**
-- `notes.size` が **上限（20件）を超える**
-
-レスポンス例：
-
-```json
-{
-  "errors": ["notes must be a non-empty array"]
-}
-```
-
-### 404 Not Found（Bulk Create 固有ルール）
-対象の Book が存在しない場合、404 を返す。
-
-```json
-{
-  "errors": ["book not found"]
-}
-```
-
-## 6.2. Bulk Create 固有の 422 エラー形式
-Bulk Create では、どの入力行が invalid だったかを返す必要があるため
-共通レスポンス { "errors": [...] } を拡張した専用形式を使用する。
-
-```json
-{
-  "errors": [
     {
-      "index": 0,
-      "messages": ["page must be greater than 0"]
+      "page": 12,
+      "quote": "引用文1",
+      "memo": "メモ1"
     },
     {
-      "index": 2,
-      "messages": ["quote can't be blank"]
+      "page": 13,
+      "quote": "引用文2",
+      "memo": null
     }
   ]
 }
-
 ```
-- index: notes 配列内の番号
-- messages: その Note に対する複数のバリデーションエラー
 
-この 422 が返るとき、
-トランザクションは 1 件も保存せず全ロールバックされる。
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `notes` | array | Yes | Noteオブジェクトの配列 |
+| `notes[].page` | integer | Yes | ページ番号。1以上 |
+| `notes[].quote` | string | Yes | 引用文。最大1000文字 |
+| `notes[].memo` | string / null | No | メモ。最大2000文字 |
 
-## 6.3. トランザクション境界とエラーの関係（Bulk 固有）
--	1件でも invalid → 全件ロールバック
--	成功時は 201（Created）
--	部分成功は仕様上禁止（atomicity）
+---
 
+## 5. Validation Rules
 
+### `notes`
 
-## 7. DB 制約（この API が前提とするもの）
+- 必須
+- 配列であること
+- 各要素はNoteオブジェクトであること
 
-- `notes.book_id` は `books.id` への外部キーとする
-  - 誤削除を避けるため、`ON DELETE RESTRICT` を採用
-- `quote` / `memo` の長さ制約は DB 側カラム定義と揃える
-  - `quote`：最大 1000 文字
-  - `memo`：最大 2000 文字
+`notes` が存在しない、配列でない、または要素がオブジェクトでない場合は `400 Bad Request` を返す。
 
-※ `(book_id, page, quote)` に対するユニーク制約は **MVP では貼らない**
-  - 同じページ・同じ引用を重複して残したいケースも考えられるため
-  - 重複禁止の要件が出た場合に、(book_id, page, quote) に unique index を追加する
+```json
+{
+  "error": {
+    "code": "bad_request",
+    "message": "Bad request"
+  }
+}
+```
 
+### `notes[].page`
 
-## 8 同時実行時のふるまい（簡易メモ）
+- 必須
+- integer
+- 1以上
 
-- 同時 Bulk Create の整合性は “atomic(全成功/全失敗)” は transaction が担保
-- 競合時はDBのロック/分離レベルに依存。必要なら明示ロック
+### `notes[].quote`
 
-## 8.1 (将来)同時実行時のふるまい（簡易メモ）
+- 必須
+- 空文字は不可
+- 最大1000文字
 
-- 同一 book に対する同時 Bulk Create は、
-  Book 行に対する明示ロック（例: SELECT ... FOR UPDATE）を取得することで
-  アプリケーションレベルで順序実行を保証する
-- Book 削除と Bulk Create が競合した場合、
-  外部キー制約（ON DELETE RESTRICT）により Bulk Create が失敗する
+### `notes[].memo`
 
-詳細は transaction_policy.md を参照。
+- 任意
+- `null` 可
+- 最大2000文字
 
+---
 
-## 9. Transaction Boundary（この API が守る境界）
+## 6. Success Response
 
-- 本エンドポイントは 1 HTTP Request を
-  1つの論理的な書き込み単位（atomic operation） として扱う。
+全件validな場合、すべてのNoteを作成し、`201 Created` を返す。
 
-不変条件（Invariant）：：
+**201 Created**
 
-- notes は「全部成功」または「全部失敗」のどちらか
-- 部分的に保存される状態は発生しない
+```json
+{
+  "notes": [
+    {
+      "id": 101,
+      "page": 12,
+      "quote": "引用文1",
+      "memo": "メモ1",
+      "created_at": "2026-06-11T04:00:14.239Z"
+    },
+    {
+      "id": 102,
+      "page": 13,
+      "quote": "引用文2",
+      "memo": null,
+      "created_at": "2026-06-11T04:00:14.670Z"
+    }
+  ],
+  "meta": {
+    "created_count": 2
+  }
+}
+```
 
-> **Transaction 観点メモ**
-> - このエンドポイント単位で **1トランザクション** を張る  
-> - 読み取り系（GET /notes など）とは違い、「書き込み系の境界」として扱う
+### Response Fields
 
-詳細なトランザクション方針（例：失敗時の扱い・整合性維持の仕組み）は
-transaction_policy.md を参照。
+| Field | Type | Description |
+|-------|------|-------------|
+| `notes` | array | 作成されたNote一覧 |
+| `notes[].id` | integer | Note ID |
+| `notes[].page` | integer | ページ番号 |
+| `notes[].quote` | string | 引用文 |
+| `notes[].memo` | string / null | メモ |
+| `notes[].created_at` | string | 作成日時 |
+| `meta.created_count` | integer | 作成件数 |
+
+---
+
+## 7. Error Responses
+
+### 400 Bad Request
+
+リクエスト構造が不正な場合。
+
+例：
+
+- `notes` が存在しない
+- `notes` が配列でない
+- `notes` の要素がオブジェクトでない
+
+```json
+{
+  "error": {
+    "code": "bad_request",
+    "message": "Bad request"
+  }
+}
+```
+
+---
+
+### 401 Unauthorized
+
+認証に失敗した場合。
+
+```json
+{
+  "error": {
+    "code": "unauthorized",
+    "message": "Authentication required"
+  }
+}
+```
+
+---
+
+### 404 Not Found
+
+対象Bookが存在しない、削除済み、またはログイン中ユーザーの所有Bookではない場合。
+
+```json
+{
+  "error": {
+    "code": "not_found",
+    "message": "Resource not found"
+  }
+}
+```
+
+---
+
+### 422 Unprocessable Entity
+
+1件以上のNoteがvalidationに失敗した場合。  
+この場合、DBには1件も作成されない。
+
+```json
+{
+  "error": {
+    "code": "unprocessable_entity",
+    "message": "Validation failed",
+    "details": [
+      {
+        "index": 1,
+        "messages": [
+          "Quote can't be blank",
+          "Page must be greater than or equal to 1"
+        ]
+      }
+    ]
+  }
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `details[].index` | integer | エラーが発生した `notes` 配列のインデックス。0始まり |
+| `details[].messages` | string[] | そのNoteに対するvalidation error |
+
+---
+
+## 8. Transaction Boundary
+
+このAPIは、1 HTTP requestを1つの論理的な書き込み単位として扱う。
+
+### Invariant
+
+- 全件validな場合のみ保存する
+- 1件でもinvalidな場合は全件保存しない
+- 部分成功は禁止
+- 422が返る場合、DBには1件も作成されない
+
+```text
+valid notes only
+→ 201 Created
+→ all notes are saved
+
+one or more invalid notes
+→ 422 Unprocessable Entity
+→ no notes are saved
+```
+
+---
+
+## 9. DB Constraints
+
+このAPIは、Rails側validationに加えてDB制約によって整合性を担保する。
+
+| Table | Column | Constraint |
+|-------|--------|------------|
+| `notes` | `book_id` | NOT NULL / FK |
+| `notes` | `page` | NOT NULL / CHECK `page >= 1` |
+| `notes` | `quote` | NOT NULL / CHECK `char_length(quote) <= 1000` |
+| `notes` | `memo` | CHECK `memo IS NULL OR char_length(memo) <= 2000` |
+
+`notes.book_id → books.id` は `ON DELETE RESTRICT` とし、物理削除時の参照整合性をDBレベルで守る。
+
+なお、MVPでは `(book_id, page, quote)` に対するunique制約は設定しない。  
+同じページ・同じ引用を重複して残したいケースも考えられるためである。
+
+---
+
+## 10. 本番確認済み挙動
+
+本番環境で以下を確認済み。
+
+- 正常系
+  - `POST /api/books/:book_id/notes/bulk`
+  - `201 Created`
+  - `meta.created_count: 3`
+
+- 一部invalid
+  - `422 Unprocessable Entity`
+  - `details` に `index` と `messages` を返す
+  - 同一indexに複数のエラーメッセージが入る
+  - DBには1件も作成されない
+
+- 他ユーザーBookへのBulk Create
+  - `404 Not Found`
+  - 所有権情報を露出しない
+
+---

--- a/backend/docs/40_api/api_overview.md
+++ b/backend/docs/40_api/api_overview.md
@@ -1,22 +1,31 @@
-
-# 読書引用インボックス API 仕様
+# Reading Notes Backend API 仕様
 
 > 📌 Docs Policy  
-> 本APIドキュメントは契約仕様です。  
+> 本APIドキュメントは、Reading Notes Backend API の契約仕様です。  
+> 主要エンドポイント、認証方式、HTTPステータス、エラーレスポンス形式を定義します。  
 > 実装アウトラインや設計方針との役割分担については  
 > 👉 [`docs/99_meta/docs_policy.md`](../99_meta/docs_policy.md) を参照してください。
 
-## 0. 設計の目的（スタックフレームのアウトプット）
+---
 
-- 1リクエスト = 1スタックフレーム という前提で設計している。
-  - コントローラの役割は「引数（パラメータ）を受け取り、Service を呼び、戻り値を JSON に変換する」だけ。
-  - セッションに状態を隠さず、必要な状態はすべて DB とリクエストパラメータで表現する。
-- 複雑な検索ロジック・ページネーションは `Notes::SearchNotes` Service に集約する。
-  - Controller に `if params[:q] ...` や `where` の羅列を書かない。
-- この API で示したいこと：
-  - スタックフレームの概念を HTTP レイヤに落とし込んだ「関数っぽい」設計ができていること。
-  - rails の「太ったコントローラ」パターンを避けて、Service レイヤで責務を分離できていること。
+## 0. 設計の目的
 
+Reading Notes Backend API は、読書メモを管理するためのバックエンドAPIです。
+
+単なるCRUDだけでなく、以下を意識して設計しています。
+
+- Bearer Token 認証
+- ログイン中ユーザーごとの所有権境界
+- Book の論理削除
+- DB制約とRails側バリデーションによる整合性担保
+- Controller / Service の責務分離
+- 共通エラーレスポンス形式の統一
+- RSpec による認証・所有権・異常系の確認
+
+Book ID を受け取る Notes 系 API では、Controller 側で認証・所有権・未削除Bookであることを確認し、Service 層には確認済みの Book を渡します。  
+これにより、Controller はHTTP境界の確認、Service は処理本体に責務を集中させます。
+
+---
 
 ## 1. 共通仕様
 
@@ -24,124 +33,380 @@
 - Format: JSON
 - Header:
   - `Content-Type: application/json`
-- エラー時:
-  - 共通フォーマットは `{ "errors": [ "message1", "message2", ... ] }`
-  - ステータスコードで種類を区別（400 / 404 / 422 / 500）
+  - `Authorization: Bearer <token>`
+
+原則として `/api` 配下のAPIは Bearer Token 認証を必要とします。  
+例外として、以下のエンドポイントは認証不要です。
+
+- `POST /api/users`
+- `POST /api/auth/session`
 
 ---
-### 1.1 共通レスポンス形式
 
+### 1.1 認証仕様
+
+本APIでは Bearer Token 認証を使用します。
+
+`POST /api/auth/session` でログインすると、生のAccess Tokenを返します。  
+サーバ側ではTokenを平文保存せず、SHA256でdigest化した `token_digest` を保存します。
+
+認証が必要なAPIでは、以下のHeaderを付与します。
+
+```http
+Authorization: Bearer <token>
+```
+
+Tokenは以下の条件を満たす場合のみ有効です。
+
+- `revoked_at` が `nil`
+- `expires_at` が現在時刻より後
+
+Tokenなし、Bearer形式でないHeader、空Token、無効Token、期限切れToken、revoked Token の場合は `401 Unauthorized` を返します。
+
+---
+
+### 1.2 所有権境界
+
+Book / Note 関連APIでは、ログイン中ユーザーが所有するデータのみを対象とします。
+
+Book ID を受け取るAPIでは、Controller側で以下の条件を満たすBookを取得します。
+
+- ログイン中ユーザーが所有していること
+- `deleted_at` が `nil` であること
+
+Bookが存在しない、削除済み、または他ユーザー所有の場合は `404 Not Found` として扱います。  
+これはリソースの存在有無や所有関係を外部に露出しないためです。
+
+---
+
+### 1.3 共通エラーレスポンス形式
+
+失敗時は、原則として以下の形式を返します。
 
 ```json
 {
-  "errors": [
-    "error message 1",
-    "error message 2"
-  ]
+  "error": {
+    "code": "error_code",
+    "message": "error message"
+  }
 }
 ```
 
-### 1.2 API 共通エラー仕様
-
-このドキュメントは、全 API エンドポイントが従うべき  
-**エラーモデル・ステータスコードの使い分け・レスポンス形式** を定義する。
-
-アプリ全体で統一したエラーハンドリングを行うことで、
-実装・テスト・クライアントの利用体験を一貫させることを目的とする。
-
----
-
-# 1.2.1 ステータスコードの基本方針
-
-## 400 Bad Request  
-**「リクエスト形式が壊れている or 必須構造を満たさない」**
-
-例：
-- 期待する JSON 構造でない
-- 必須フィールドが欠落している（例：`notes` が存在しない）
-- 配列が空である（`notes` が空）
-- 上限件数など、リクエスト構造的な制約違反
-
----
-
-## 404 Not Found  
-**「対象リソースが存在しない」**
-
-例：
-- `book_id` に対応する Book が存在しない
-- URL の ID に対応するリソースがない
-
----
-
-## 422 Unprocessable Entity  
-**「リクエスト形式は正しいが、モデルバリデーションに失敗」**
-
-例：
-- Note の `quote` が空
-- `page` が 1 未満
-- BulkCreate の中で `notes` の要素が部分的に invalid
-
----
-
-## 500 Internal Server Error  
-**「サーバ側の想定外のエラー」**
-
-- 500 は予期しないエラー
-
-
----
-
-# 1.2.2. 共通レスポンス形式
-
-成功時：  
-（各 API の設計に依存するため省略）
-
-失敗時（全API共通）：
+詳細情報がある場合は `details` を含めます。
 
 ```json
 {
-  "errors": [
-    "error message 1",
-    "error message 2"
-  ]
+  "error": {
+    "code": "unprocessable_entity",
+    "message": "Validation failed",
+    "details": [
+      "Title can't be blank"
+    ]
+  }
 }
-
 ```
 
-# 1.2.3. Bulk API 固有の 422 形式
-BulkCreate のみ、
-「どの要素が失敗したか」を示す専用形式を採用する。
+---
+
+### 1.4 ステータスコードの基本方針
+
+#### 400 Bad Request
+
+リクエスト形式が不正な場合。
+
+例：
+
+- 期待するJSON構造でない
+- 必須パラメータが欠落している
+- 配列であるべき値が配列でない
+- クエリパラメータの型が不正
 
 ```json
 {
-  "errors": [
-    {
-      "index": 0,
-      "messages": ["Page must be greater than or equal to 1"]
-    },
-    {
-      "index": 2,
-      "messages": ["Quote can't be blank"]
-    }
-  ]
+  "error": {
+    "code": "bad_request",
+    "message": "Bad request"
+  }
 }
-
 ```
-- index は notes 内のインデックス番号
-- messages は複数のバリデーションメッセージ配列
-- API 全体の { "errors": [...] } ルート形式は維持する
+
+---
+
+#### 401 Unauthorized
+
+認証が必要なAPIで、Tokenがない、またはTokenが無効な場合。
+
+```json
+{
+  "error": {
+    "code": "unauthorized",
+    "message": "Authentication required"
+  }
+}
+```
+
+---
+
+#### 404 Not Found
+
+対象リソースが存在しない、またはログイン中ユーザーがアクセス可能な範囲に存在しない場合。
+
+```json
+{
+  "error": {
+    "code": "not_found",
+    "message": "Resource not found"
+  }
+}
+```
+
+---
+
+#### 422 Unprocessable Entity
+
+リクエスト形式は正しいが、モデルバリデーションまたはDB制約に違反した場合。
+
+```json
+{
+  "error": {
+    "code": "unprocessable_entity",
+    "message": "Validation failed",
+    "details": [
+      "Title can't be blank"
+    ]
+  }
+}
+```
+
+DB制約違反の場合。
+
+```json
+{
+  "error": {
+    "code": "db_constraint_violation",
+    "message": "DB constraint violated"
+  }
+}
+```
+
+---
+
+#### 500 Internal Server Error
+
+本番環境でサーバ側の想定外エラーが発生した場合。
+
+```json
+{
+  "error": {
+    "code": "internal_server_error",
+    "message": "Internal server error"
+  }
+}
+```
+
+---
+
+### 1.5 Bulk API 固有の422形式
+
+Bulk Create では、「どの要素が失敗したか」を `details` に含めます。  
+同一indexに複数のエラーメッセージが入る場合があります。
+
+```json
+{
+  "error": {
+    "code": "unprocessable_entity",
+    "message": "Validation failed",
+    "details": [
+      {
+        "index": 1,
+        "messages": [
+          "Quote can't be blank",
+          "Page must be greater than or equal to 1"
+        ]
+      }
+    ]
+  }
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `details[].index` | integer | エラーが発生した `notes` 配列のインデックス。0始まり |
+| `details[].messages` | string[] | そのインデックスで発生したバリデーションエラーメッセージ |
+
+---
 
 ## 2. Endpoints
 
 ---
 
-### 2.1 Books
+### 2.1 Health
+
+#### GET /healthz
+
+アプリケーションの稼働確認用エンドポイントです。
+
+##### Response
+
+**200 OK**
+
+```json
+{
+  "ok": true
+}
+```
 
 ---
 
+### 2.2 Users
+
+#### POST /api/users
+
+ユーザーを作成します。  
+このエンドポイントは認証不要です。
+
+##### Request
+
+```json
+{
+  "user": {
+    "name": "Taro",
+    "email": "user@example.com",
+    "password": "password",
+    "password_confirmation": "password"
+  }
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | No | ユーザー名 |
+| `email` | string | Yes | メールアドレス。一意制約あり |
+| `password` | string | Yes | パスワード |
+| `password_confirmation` | string | No | パスワード確認 |
+
+##### Response
+
+**201 Created**
+
+```json
+{
+  "id": 1,
+  "name": "Taro",
+  "email": "user@example.com"
+}
+```
+
+##### Error
+
+**422 Unprocessable Entity**
+
+```json
+{
+  "error": {
+    "code": "unprocessable_entity",
+    "message": "Validation failed",
+    "details": [
+      "Email has already been taken"
+    ]
+  }
+}
+```
+
+---
+
+### 2.3 Auth
+
+#### POST /api/auth/session
+
+ログインし、Bearer Tokenを発行します。  
+このエンドポイントは認証不要です。
+
+##### Request
+
+```json
+{
+  "email": "user@example.com",
+  "password": "password"
+}
+```
+
+##### Response
+
+**200 OK**
+
+```json
+{
+  "token": "<token>"
+}
+```
+
+##### Error
+
+**401 Unauthorized**
+
+email / password が空、または認証に失敗した場合。
+
+```json
+{
+  "error": {
+    "code": "unauthorized",
+    "message": "Authentication required"
+  }
+}
+```
+
+---
+
+#### DELETE /api/auth/session
+
+現在のBearer Tokenをrevoked状態にし、ログアウトします。
+
+##### Header
+
+```http
+Authorization: Bearer <token>
+```
+
+##### Response
+
+**200 OK**
+
+```json
+{
+  "ok": true
+}
+```
+
+##### Error
+
+**401 Unauthorized**
+
+Tokenがない、無効、期限切れ、またはrevoked済みの場合。
+
+```json
+{
+  "error": {
+    "code": "unauthorized",
+    "message": "Authentication required"
+  }
+}
+```
+
+---
+
+### 2.4 Books
+
 #### GET /api/books
 
-Book 一覧を取得する。論理削除された Book は含まれない。
+ログイン中ユーザーが所有する未削除Book一覧を取得します。  
+削除済みBookは含まれません。
+
+##### Header
+
+```http
+Authorization: Bearer <token>
+```
 
 ##### Response
 
@@ -162,14 +427,33 @@ Book 一覧を取得する。論理削除された Book は含まれない。
 ]
 ```
 
-- 配列は `created_at` 降順でソートされる
-- Book が存在しない場合は空配列 `[]` を返す
+- 配列は `created_at` 降順でソートされます
+- Bookが存在しない場合は空配列 `[]` を返します
+
+##### Error
+
+**401 Unauthorized**
+
+```json
+{
+  "error": {
+    "code": "unauthorized",
+    "message": "Authentication required"
+  }
+}
+```
 
 ---
 
 #### POST /api/books
 
-新しい Book を作成する。
+ログイン中ユーザーに紐づくBookを作成します。
+
+##### Header
+
+```http
+Authorization: Bearer <token>
+```
 
 ##### Request
 
@@ -184,8 +468,8 @@ Book 一覧を取得する。論理削除された Book は含まれない。
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| title | string | Yes | 書籍タイトル |
-| author | string | No | 著者名 |
+| `title` | string | Yes | 書籍タイトル |
+| `author` | string | No | 著者名 |
 
 ##### Response
 
@@ -199,31 +483,103 @@ Book 一覧を取得する。論理削除された Book は含まれない。
 }
 ```
 
+##### Error
+
+**401 Unauthorized**
+
+```json
+{
+  "error": {
+    "code": "unauthorized",
+    "message": "Authentication required"
+  }
+}
+```
+
 **422 Unprocessable Entity**
 
 ```json
 {
-  "errors": [
-    "Title can't be blank"
-  ]
+  "error": {
+    "code": "unprocessable_entity",
+    "message": "Validation failed",
+    "details": [
+      "Title can't be blank"
+    ]
+  }
 }
 ```
 
 ---
 
-### 2.2 Notes
+#### DELETE /api/books/:id
 
----
+ログイン中ユーザーが所有する未削除Bookを論理削除します。  
+物理削除ではなく、`deleted_at` を現在時刻で更新します。
 
-#### POST /api/books/:book_id/notes
+##### Header
 
-指定した Book に Note を1件作成する。
+```http
+Authorization: Bearer <token>
+```
 
 ##### Path Parameters
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| book_id | integer | Book の ID |
+| `id` | integer | Book の ID |
+
+##### Response
+
+**204 No Content**
+
+レスポンスボディなし。
+
+##### Error
+
+**401 Unauthorized**
+
+```json
+{
+  "error": {
+    "code": "unauthorized",
+    "message": "Authentication required"
+  }
+}
+```
+
+**404 Not Found**
+
+Bookが存在しない、削除済み、またはログイン中ユーザーの所有Bookではない場合。
+
+```json
+{
+  "error": {
+    "code": "not_found",
+    "message": "Resource not found"
+  }
+}
+```
+
+---
+
+### 2.5 Notes
+
+#### POST /api/books/:book_id/notes
+
+ログイン中ユーザーが所有する未削除BookにNoteを1件作成します。
+
+##### Header
+
+```http
+Authorization: Bearer <token>
+```
+
+##### Path Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `book_id` | integer | Book の ID |
 
 ##### Request
 
@@ -239,9 +595,9 @@ Book 一覧を取得する。論理削除された Book は含まれない。
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| page | integer | Yes | ページ番号（1以上）。DB NOT NULL 制約により必須 |
-| quote | string | Yes | 引用文（最大1000文字） |
-| memo | string | No | メモ（最大2000文字） |
+| `page` | integer | Yes | ページ番号。1以上 |
+| `quote` | string | Yes | 引用文。最大1000文字 |
+| `memo` | string | No | メモ。最大2000文字 |
 
 ##### Response
 
@@ -258,110 +614,145 @@ Book 一覧を取得する。論理削除された Book は含まれない。
 }
 ```
 
-**404 Not Found**
+##### Error
 
-Book が存在しない、または論理削除されている場合。
+**401 Unauthorized**
 
 ```json
 {
-  "errors": [
-    "Couldn't find Book with 'id'=999"
-  ]
+  "error": {
+    "code": "unauthorized",
+    "message": "Authentication required"
+  }
+}
+```
+
+**404 Not Found**
+
+Bookが存在しない、削除済み、またはログイン中ユーザーの所有Bookではない場合。
+
+```json
+{
+  "error": {
+    "code": "not_found",
+    "message": "Resource not found"
+  }
 }
 ```
 
 **422 Unprocessable Entity**
 
-バリデーションエラーが発生した場合。
+Noteのバリデーションに失敗した場合。
 
 ```json
 {
-  "errors": [
-    "Quote can't be blank"
-  ]
-}
-```
-
-```json
-{
-  "errors": [
-    "Page is not a number"
-  ]
-}
-```
-
-```json
-{
-  "errors": [
-    "Page must be greater than or equal to 1"
-  ]
+  "error": {
+    "code": "unprocessable_entity",
+    "message": "Validation failed",
+    "details": [
+      "Quote can't be blank"
+    ]
+  }
 }
 ```
 
 ---
 
-#### DELETE /api/notes/:id
+#### DELETE /api/books/:book_id/notes/:id
 
-Note を削除する。
+ログイン中ユーザーが所有する未削除Bookに紐づくNoteを削除します。
+
+##### Header
+
+```http
+Authorization: Bearer <token>
+```
 
 ##### Path Parameters
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| id | integer | Note の ID |
+| `book_id` | integer | Book の ID |
+| `id` | integer | Note の ID |
 
 ##### Response
 
 **204 No Content**
 
-（レスポンスボディなし）
+レスポンスボディなし。
 
-**404 Not Found**
+##### Error
 
-Note が存在しない場合。
+**401 Unauthorized**
 
 ```json
 {
-  "errors": [
-    "Couldn't find Note with 'id'=999"
-  ]
+  "error": {
+    "code": "unauthorized",
+    "message": "Authentication required"
+  }
+}
+```
+
+**404 Not Found**
+
+Bookが存在しない、削除済み、他ユーザー所有、または指定NoteがそのBookに存在しない場合。
+
+```json
+{
+  "error": {
+    "code": "not_found",
+    "message": "Resource not found"
+  }
 }
 ```
 
 ---
 
-### 2.3 Notes Bulk Create
-
----
+### 2.6 Notes Bulk Create
 
 #### POST /api/books/:book_id/notes/bulk
 
-指定した Book に複数の Note を一括作成する。
-全件成功 or 全件失敗（トランザクション）。
+ログイン中ユーザーが所有する未削除Bookに、複数のNoteを一括作成します。  
+全件成功 or 全件失敗のトランザクションとして扱います。
+
+##### Header
+
+```http
+Authorization: Bearer <token>
+```
 
 ##### Path Parameters
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| book_id | integer | Book の ID |
+| `book_id` | integer | Book の ID |
 
 ##### Request
 
 ```json
 {
   "notes": [
-    { "page": 10, "quote": "引用文1", "memo": "メモ1" },
-    { "page": 20, "quote": "引用文2", "memo": null }
+    {
+      "page": 10,
+      "quote": "引用文1",
+      "memo": "メモ1"
+    },
+    {
+      "page": 20,
+      "quote": "引用文2",
+      "memo": null
+    }
   ]
 }
 ```
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| notes | array | Yes | Note オブジェクトの配列（1〜20件） |
-| notes[].page | integer | Yes | ページ番号（1以上）。DB NOT NULL 制約により必須 |
-| notes[].quote | string | Yes | 引用文（最大1000文字） |
-| notes[].memo | string | No | メモ（最大2000文字） |
+| `notes` | array | Yes | Noteオブジェクトの配列 |
+| `notes[].page` | integer | Yes | ページ番号。1以上 |
+| `notes[].quote` | string | Yes | 引用文。最大1000文字 |
+| `notes[].memo` | string | No | メモ。最大2000文字 |
 
 ##### Response
 
@@ -391,90 +782,97 @@ Note が存在しない場合。
 }
 ```
 
+##### Error
+
 **400 Bad Request**
 
 リクエスト構造が不正な場合。
 
 ```json
 {
-  "errors": [
-    "notes must be provided"
-  ]
+  "error": {
+    "code": "bad_request",
+    "message": "Bad request"
+  }
 }
 ```
 
-その他の 400 ケース:
-- `"notes must be an array"` — notes が配列でない
-- `"notes[0] must be an object"` — 配列要素がオブジェクトでない
-- `"notes must be a non-empty array"` — 空配列
-- `"too many notes (max 20)"` — 21件以上
+**401 Unauthorized**
+
+```json
+{
+  "error": {
+    "code": "unauthorized",
+    "message": "Authentication required"
+  }
+}
+```
 
 **404 Not Found**
 
-Book が存在しない、または論理削除されている場合。
+Bookが存在しない、削除済み、またはログイン中ユーザーの所有Bookではない場合。
 
 ```json
 {
-  "errors": [
-    "Couldn't find Book with 'id'=999"
-  ]
+  "error": {
+    "code": "not_found",
+    "message": "Resource not found"
+  }
 }
 ```
 
-**422 Unprocessable Entity（Bulk 専用形式）**
+**422 Unprocessable Entity**
 
-1件以上のバリデーションエラーがある場合。
-**注意**: このエンドポイントのみ structured errors 形式を採用する。
+1件以上のバリデーションエラーがある場合。  
+この場合、DBには1件も作成されません。
 
 ```json
 {
-  "errors": [
-    {
-      "index": 1,
-      "messages": [
-        "Quote can't be blank"
-      ]
-    },
-    {
-      "index": 3,
-      "messages": [
-        "Page must be greater than or equal to 1"
-      ]
-    }
-  ]
+  "error": {
+    "code": "unprocessable_entity",
+    "message": "Validation failed",
+    "details": [
+      {
+        "index": 1,
+        "messages": [
+          "Quote can't be blank",
+          "Page must be greater than or equal to 1"
+        ]
+      }
+    ]
+  }
 }
 ```
 
-| Field | Type | Description |
-|-------|------|-------------|
-| errors[].index | integer | エラーが発生した notes 配列のインデックス（0始まり） |
-| errors[].messages | string[] | そのインデックスで発生したバリデーションエラーメッセージ |
-
 ---
 
-### 2.4 Notes Search
-
----
+### 2.7 Notes Search
 
 #### GET /api/books/:book_id/notes_search
 
-指定した Book の Note を検索・フィルタリング・ページネーションして取得する。
+ログイン中ユーザーが所有する未削除BookのNoteを検索・フィルタリング・ページネーションして取得します。
+
+##### Header
+
+```http
+Authorization: Bearer <token>
+```
 
 ##### Path Parameters
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| book_id | integer | Book の ID |
+| `book_id` | integer | Book の ID |
 
 ##### Query Parameters
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
-| q | string | No | — | 検索キーワード（quote または memo に部分一致、スペース区切りで AND 検索） |
-| page_from | integer | No | — | ページ番号の下限（この値以上） |
-| page_to | integer | No | — | ページ番号の上限（この値以下） |
-| page | integer | No | 1 | ページネーションのページ番号 |
-| limit | integer | No | 50 | 1ページあたりの件数（最大200） |
+| `q` | string | No | — | 検索キーワード。quote または memo に部分一致。スペース区切りでAND検索 |
+| `page_from` | integer | No | — | ページ番号の下限 |
+| `page_to` | integer | No | — | ページ番号の上限 |
+| `page` | integer | No | 1 | ページネーションのページ番号 |
+| `limit` | integer | No | 50 | 1ページあたりの件数。最大200 |
 
 ##### Response
 
@@ -501,13 +899,29 @@ Book が存在しない、または論理削除されている場合。
 }
 ```
 
+検索条件に一致するNoteが存在しない場合は、`200 OK` で `notes: []` を返します。
+
+```json
+{
+  "notes": [],
+  "meta": {
+    "total_count": 0,
+    "page": 1,
+    "limit": 10,
+    "total_pages": 0
+  }
+}
+```
+
 | Field | Type | Description |
 |-------|------|-------------|
-| notes | array | Note オブジェクトの配列（`created_at` 降順） |
-| meta.total_count | integer | フィルタ条件に合致する全件数 |
-| meta.page | integer | 現在のページ番号 |
-| meta.limit | integer | 1ページあたりの件数 |
-| meta.total_pages | integer | 総ページ数 |
+| `notes` | array | Noteオブジェクトの配列 |
+| `meta.total_count` | integer | フィルタ条件に合致する全件数 |
+| `meta.page` | integer | 現在のページ番号 |
+| `meta.limit` | integer | 1ページあたりの件数 |
+| `meta.total_pages` | integer | 総ページ数 |
+
+##### Error
 
 **400 Bad Request**
 
@@ -515,55 +929,459 @@ Book が存在しない、または論理削除されている場合。
 
 ```json
 {
-  "errors": [
-    "page must be an integer or nil"
-  ]
+  "error": {
+    "code": "bad_request",
+    "message": "Bad request"
+  }
 }
 ```
 
-その他の 400 ケース:
-- `"limit must be an integer or nil"`
-- `"page_from and page_to must be integers"`
-- `"page_from must be less than or equal to page_to"`
-
-**404 Not Found**
-
-Book が存在しない、または論理削除されている場合。
+**401 Unauthorized**
 
 ```json
 {
-  "errors": [
-    "Couldn't find Book with 'id'=999"
-  ]
+  "error": {
+    "code": "unauthorized",
+    "message": "Authentication required"
+  }
+}
+```
+
+**404 Not Found**
+
+Bookが存在しない、削除済み、またはログイン中ユーザーの所有Bookではない場合。
+
+```json
+{
+  "error": {
+    "code": "not_found",
+    "message": "Resource not found"
+  }
 }
 ```
 
 ---
 
-### 2.5 共通エラーレスポンス
+## 3. DB制約とRails側制御
 
-すべてのエンドポイントで発生しうる共通エラー。
+本APIでは、Rails側のバリデーションに加えて、DB制約でもデータ整合性を担保します。
 
-**422 Unprocessable Entity（DB制約違反）**
+主なDB制約は以下です。
 
-モデルバリデーションをすり抜けた入力が DB 制約に違反した場合。
-NotNullViolation / InvalidForeignKey / RecordNotUnique / CheckViolation が対象。
+| Table | Column | Constraint |
+|-------|--------|------------|
+| `users` | `email` | NOT NULL / UNIQUE |
+| `users` | `password_digest` | NOT NULL |
+| `access_tokens` | `user_id` | NOT NULL / FK |
+| `access_tokens` | `token_digest` | NOT NULL / UNIQUE |
+| `access_tokens` | `expires_at` | NOT NULL |
+| `books` | `title` | NOT NULL |
+| `books` | `user_id` | NOT NULL / FK |
+| `notes` | `book_id` | NOT NULL / FK |
+| `notes` | `page` | NOT NULL / CHECK `page >= 1` |
+| `notes` | `quote` | NOT NULL / CHECK `char_length(quote) <= 1000` |
+| `notes` | `memo` | CHECK `memo IS NULL OR char_length(memo) <= 2000` |
+
+DB制約違反は `422 Unprocessable Entity` として扱います。
 
 ```json
 {
-  "errors": [
-    "DB constraint violated"
-  ]
+  "error": {
+    "code": "db_constraint_violation",
+    "message": "DB constraint violated"
+  }
 }
 ```
 
-**500 Internal Server Error**
+---
 
-サーバ側の想定外エラー（本番環境のみ）。
+## 4. 本番確認済みフロー
+
+以下は、本番環境で確認済みの代表的な認証付きAPI操作フローです。
+
+---
+
+### 4.0 実行用Base URL
+
+```bash
+
+BASE_URL="https://backend-withered-voice-4962.fly.dev"
+
+```
+
+Health Check:
+
+```bash
+
+curl "$BASE_URL/healthz"
+
+```
+
+期待値:
+
+```json
+
+{
+
+  "ok": true
+
+}
+
+```
+
+---
+
+### 4.1 Quick Evaluation Route
+
+本番環境で最小限の動作確認を行う場合は、以下の順で確認できます。
+
+1. `GET /healthz`
+
+2. `POST /api/users`
+
+3. `POST /api/auth/session`
+
+4. `GET /api/books` with Bearer Token
+
+5. `POST /api/books` with Bearer Token
+
+6. `DELETE /api/books/:id` with Bearer Token
+
+詳細なリクエスト・レスポンス例は、次の `Book操作` セクションを参照してください。
+
+---
+
+### 4.2 Book操作
+
+#### 1. ログイン / Token発行
+
+`POST /api/auth/session`
+
+**200 OK**
 
 ```json
 {
-  "errors": [
-    "Internal server error"
-  ]
+  "token": "<token>"
 }
+```
+
+---
+
+#### 2. Bearer Token付きでBook一覧取得
+
+`GET /api/books`
+
+Header:
+
+```http
+Authorization: Bearer <token>
+```
+
+**200 OK**
+
+```json
+[]
+```
+
+---
+
+#### 3. Bearer Token付きでBook作成
+
+`POST /api/books`
+
+Header:
+
+```http
+Authorization: Bearer <token>
+```
+
+Request:
+
+```json
+{
+  "book": {
+    "title": "Clean Architecture",
+    "author": "Robert C. Martin"
+  }
+}
+```
+
+**201 Created**
+
+```json
+{
+  "id": 8,
+  "title": "Clean Architecture",
+  "author": "Robert C. Martin"
+}
+```
+
+---
+
+#### 4. 作成したBookが一覧に含まれることを確認
+
+`GET /api/books`
+
+Header:
+
+```http
+Authorization: Bearer <token>
+```
+
+**200 OK**
+
+```json
+[
+  {
+    "id": 8,
+    "title": "Clean Architecture",
+    "author": "Robert C. Martin"
+  }
+]
+```
+
+---
+
+#### 5. Bookを論理削除
+
+`DELETE /api/books/:id`
+
+Header:
+
+```http
+Authorization: Bearer <token>
+```
+
+**204 No Content**
+
+レスポンスボディなし。
+
+---
+
+#### 6. 削除後、Book一覧から除外されることを確認
+
+`GET /api/books`
+
+Header:
+
+```http
+Authorization: Bearer <token>
+```
+
+**200 OK**
+
+```json
+[]
+```
+
+---
+
+### 4.3 Bulk / Search / 所有権境界
+
+以下は、本番環境で確認済みの代表的なBulk作成・検索・所有権境界確認フローです。
+
+#### Bulk Create 正常系
+
+`POST /api/books/:book_id/notes/bulk`
+
+**201 Created**
+
+```json
+{
+  "notes": [
+    {
+      "id": 19,
+      "page": 10,
+      "quote": "Clean Architecture emphasizes boundaries.",
+      "memo": "architecture memo",
+      "created_at": "2026-06-11T04:00:14.239Z"
+    },
+    {
+      "id": 20,
+      "page": 20,
+      "quote": "Ruby on Rails makes API development productive.",
+      "memo": "rails memo",
+      "created_at": "2026-06-11T04:00:14.670Z"
+    },
+    {
+      "id": 21,
+      "page": 30,
+      "quote": "Search behavior should be verified by curl.",
+      "memo": "search memo",
+      "created_at": "2026-06-11T04:00:14.879Z"
+    }
+  ],
+  "meta": {
+    "created_count": 3
+  }
+}
+```
+
+---
+
+#### Search 正常系：キーワード検索
+
+`GET /api/books/:book_id/notes_search?q=Rails&page=1&limit=10`
+
+**200 OK**
+
+```json
+{
+  "notes": [
+    {
+      "id": 20,
+      "book_id": 21,
+      "page": 20,
+      "quote": "Ruby on Rails makes API development productive.",
+      "memo": "rails memo",
+      "created_at": "2026-06-11T04:00:14.670Z"
+    }
+  ],
+  "meta": {
+    "total_count": 1,
+    "page": 1,
+    "limit": 10,
+    "total_pages": 1
+  }
+}
+```
+
+---
+
+#### Search 正常系：ページ範囲検索
+
+`GET /api/books/:book_id/notes_search?page_from=10&page_to=20&page=1&limit=10`
+
+**200 OK**
+
+```json
+{
+  "notes": [
+    {
+      "id": 20,
+      "book_id": 21,
+      "page": 20,
+      "quote": "Ruby on Rails makes API development productive.",
+      "memo": "rails memo",
+      "created_at": "2026-06-11T04:00:14.670Z"
+    },
+    {
+      "id": 19,
+      "book_id": 21,
+      "page": 10,
+      "quote": "Clean Architecture emphasizes boundaries.",
+      "memo": "architecture memo",
+      "created_at": "2026-06-11T04:00:14.239Z"
+    }
+  ],
+  "meta": {
+    "total_count": 2,
+    "page": 1,
+    "limit": 10,
+    "total_pages": 1
+  }
+}
+```
+
+---
+
+#### Search 正常系：該当なし
+
+`GET /api/books/:book_id/notes_search?q=nonexistentkeyword&page=1&limit=10`
+
+**200 OK**
+
+```json
+{
+  "notes": [],
+  "meta": {
+    "total_count": 0,
+    "page": 1,
+    "limit": 10,
+    "total_pages": 0
+  }
+}
+```
+
+---
+
+#### Bulk Create 異常系：一部invalid
+
+`POST /api/books/:book_id/notes/bulk`
+
+**422 Unprocessable Entity**
+
+```json
+{
+  "error": {
+    "code": "unprocessable_entity",
+    "message": "Validation failed",
+    "details": [
+      {
+        "index": 1,
+        "messages": [
+          "Quote can't be blank",
+          "Page must be greater than or equal to 1"
+        ]
+      }
+    ]
+  }
+}
+```
+
+この場合、全件成功 or 全件失敗のトランザクションとして扱い、DBには1件も作成されません。
+
+---
+
+#### Search 異常系：不正なクエリパラメータ
+
+`GET /api/books/:book_id/notes_search?page=abc&limit=10`
+
+**400 Bad Request**
+
+```json
+{
+  "error": {
+    "code": "bad_request",
+    "message": "Bad request"
+  }
+}
+```
+
+---
+
+#### 所有権境界：他ユーザーBookへのSearch
+
+他ユーザーが所有するBook IDを指定して、元ユーザーのTokenで検索します。
+
+`GET /api/books/:other_user_book_id/notes_search?q=Rails&page=1&limit=10`
+
+**404 Not Found**
+
+```json
+{
+  "error": {
+    "code": "not_found",
+    "message": "Resource not found"
+  }
+}
+```
+
+---
+
+#### 所有権境界：他ユーザーBookへのBulk Create
+
+他ユーザーが所有するBook IDを指定して、元ユーザーのTokenでBulk作成します。
+
+`POST /api/books/:other_user_book_id/notes/bulk`
+
+**404 Not Found**
+
+```json
+{
+  "error": {
+    "code": "not_found",
+    "message": "Resource not found"
+  }
+}
+```

--- a/backend/docs/40_api/authentication_request_specs.md
+++ b/backend/docs/40_api/authentication_request_specs.md
@@ -1,9 +1,109 @@
-## Request spec authentication policy
-
-Request specs are divided by responsibility.
-
-- `authentication_spec` はトークン未指定・不正なトークン・有効なトークンなど、認証そのものの挙動を確認する
-- books_specでは認証済みユーザーがいる前提で、Books APIのレスポンス構造や所有権スコープを確認する
-- 通常の機能ごとのrequest specでは、ログイン処理を毎回検証するのではなく、各specの責務に集中するために認証をstubする
-- 実際の認証フローを確認する必要があるspecでは、`auth: :real`を使って認証stubを回避する
-- books indexの所有権specでは、response bodyに認証済みユーザー本人のBookだけが含まれ、他ユーザーのBookが含まれないことを確認する。
+# Request Spec Authentication Policy
+## 目的
+Request spec では、認証そのものの挙動と、各APIの機能仕様を分けて確認する。
+すべてのrequest specで毎回ログイン処理を検証すると、各specの責務が曖昧になる。  
+そのため、本プロジェクトでは以下の方針でrequest specを分ける。
+---
+## 基本方針
+- 認証そのものの挙動は `authentication_spec` で確認する
+- login / logout APIそのものの挙動は `api/auth/session_spec` で確認する
+- 各APIのrequest specでは、原則として「認証済みユーザーがいる」前提で機能仕様を確認する
+- 通常の機能ごとのrequest specでは、認証フローを毎回検証せず、各specの責務に集中するために認証をstubする
+- 実際のBearer Token認証フローを確認する必要があるspecでは、`auth: :real` を使って認証stubを回避する
+---
+## `authentication_spec` の責務
+`authentication_spec` では、保護APIに対するBearer Token認証そのものの挙動を確認する。
+確認対象は以下。
+- valid Bearer token の場合は `200 OK`
+- Authorization header がない場合は `401 Unauthorized`
+- 不正なTokenの場合は `401 Unauthorized`
+- BearerのみでTokenが空の場合は `401 Unauthorized`
+- expired token の場合は `401 Unauthorized`
+- revoked token の場合は `401 Unauthorized`
+認証失敗時のレスポンス形式は以下。
+```json
+{
+  "error": {
+    "code": "unauthorized",
+    "message": "Authentication required"
+  }
+}
+```
+---
+## `api/auth/session_spec` の責務
+`api/auth/session_spec` では、login / logout APIそのものの仕様を確認する。
+確認対象は以下。
+- login成功時に raw token を返す
+- login成功時に `AccessToken` が1件作成される
+- login成功時、raw token はレスポンスで返るが、DBにはSHA256 digestのみ保存される
+- login失敗時は `401 Unauthorized` を返す
+- login失敗時は `AccessToken` が作成されない
+- logout成功時に現在のTokenがrevoked状態になる
+- logout後、同じTokenで保護APIにアクセスすると `401 Unauthorized` を返す
+- Bearer tokenなしでlogoutしようとした場合は `401 Unauthorized` を返す
+---
+## `auth: :real` の用途
+本プロジェクトでは、通常のrequest specで認証済みユーザーをstubする。  
+一方、実際のBearer Token認証フローを確認する必要があるspecでは、`auth: :real` を付与する。
+`auth: :real` が付与されたspecでは、認証stubを回避し、実際の `Authorization: Bearer <token>` ヘッダーによる認証を確認する。
+---
+## 各API request spec の責務
+Books / Notes / Bulk / Search などの機能ごとのrequest specでは、認証そのものではなく、各APIの仕様を確認する。
+例：
+- レスポンスステータス
+- レスポンスJSONの構造
+- validation error
+- RecordNotFound時の `404 Not Found`
+- 所有権境界
+- soft-deleted Book の除外
+- Bulk作成時のrollback
+- Search条件の挙動
+---
+## 認証stubを使う理由
+各APIのrequest specで毎回実際のログイン処理を通すと、失敗原因が以下のどちらか判別しにくくなる。
+- 認証処理の失敗
+- 各API本体の仕様違反
+そのため、通常の機能specでは認証済みユーザーをstubし、テスト対象をAPI本体の責務に限定する。
+```text
+authentication_spec
+→ 保護APIに対するBearer Token認証そのものを確認する
+api/auth/session_spec
+→ login / logout APIそのものを確認する
+books_spec / notes_spec / bulk_spec / search_spec
+→ 認証済みユーザーを前提に、各APIの仕様を確認する
+```
+---
+## Books request spec の方針
+`books_spec` では、認証済みユーザーがいる前提で、Books APIのレスポンス構造と所有権スコープを確認する。
+特に `GET /api/books` では、以下を確認する。
+- response body に認証済みユーザー本人のBookだけが含まれる
+- 他ユーザーのBookは含まれない
+- soft-deleted Book は含まれない
+- 配列は `created_at` 降順で返る
+- Bookが存在しない場合は空配列を返す
+所有権境界は、`current_user.books` を起点にした取得によって担保する。
+---
+## 追加するとよい認証spec
+現在のspecに加えて、以下のケースも確認すると認証仕様としてより明確になる。
+### `authentication_spec` に追加候補
+- `returns 401 when Authorization scheme is not Bearer`
+- `returns 401 when Authorization header has lowercase bearer only if implementation does not allow it`
+- `returns 401 when token digest does not match any active AccessToken`
+### `api/auth/session_spec` に追加候補
+- `revokes current token on logout`
+- `returns { ok: true } on successful logout`
+- `returns 401 when logout token is invalid`
+- `returns 401 when logout token is expired`
+- `returns 401 when logout token is already revoked`
+- `does not create AccessToken when password is wrong`
+- `does not create AccessToken when email is blank`
+- `does not store raw token in access_tokens.token_digest`
+---
+## まとめ
+本プロジェクトのrequest specでは、認証と機能仕様を混ぜずに分離して確認する。
+- 認証仕様は `authentication_spec`
+- login / logout API仕様は `api/auth/session_spec`
+- 各APIの機能仕様はそれぞれのrequest spec
+- 通常の機能specでは認証をstub
+- 実認証フローが必要な場合のみ `auth: :real`
+この方針により、specの責務を明確にし、認証・所有権・API本体の不具合を切り分けやすくしている。

--- a/backend/docs/40_api/search_notes_api.md
+++ b/backend/docs/40_api/search_notes_api.md
@@ -1,236 +1,103 @@
-# ノート一覧取得（検索＋ページネーション対応）
-
-本ドキュメントは、**構造化引用検索** の中核となるエンドポイント  
-`GET /api/books/:book_id/notes_search` の仕様だけを切り出して定義する。
-
-- Base URL（開発）: `http://localhost:3000`
-- Resource: Book に紐づく Note
-- 認証: なし（ローカル開発用）
-
+# Search Notes API Contract
+## 0. Purpose
+`GET /api/books/:book_id/notes_search` は、指定したBookに紐づくNoteを検索・フィルタリング・ページネーションして取得するAPIである。
+構造化された読書メモ検索の中核として、以下の条件でNoteを取得できるようにする。
+- キーワード検索
+- ページ範囲検索
+- ページネーション
 ---
-
-## 1. Endpoint 概要
-
-### 1.1 エンドポイント
-
-**GET /api/books/:book_id/notes_search**
-
-### 1.2 用途
-
-- 指定した Book に紐づくノート一覧を返す
-- 以下の条件で検索・絞り込み・ページングを行う
-  - キーワード検索（`q`）
-  - ページ範囲指定（`page_from` / `page_to`）
-  - ページング（`page` / `limit`）
-
-このエンドポイントが「構造化引用検索」機能の土台に
-
----
-
-## 2. パラメータ仕様
-
-### 2.1 パスパラメータ
-
-| name      | type    | 必須 | 説明                    |
-|-----------|---------|------|-------------------------|
-| `book_id` | integer | YES  | 対象となる Book の ID   |
-
----
-
-### 2.2 クエリパラメータ
-
-| name        | type    | 必須 | デフォルト | 説明                                                                 |
-|-------------|---------|------|------------|----------------------------------------------------------------------|
-| `q`         | string  | 任意 | `nil`      | `quote` / `memo` に対する部分一致キーワード                         |
-| `page_from` | integer | 任意 | `nil`      | ページ下限（例: `10` → `page >= 10`）                                |
-| `page_to`   | integer | 任意 | `nil`      | ページ上限（例: `20` → `page <= 20`）                                |
-| `page`      | integer | 任意 | `1`        | 何ページ目か（1 始まり、`page >= 1`）                                |
-| `limit`     | integer | 任意 | `50`       | 1ページあたり件数（上限 `200`。超えたら `200` にクランプ）         |
-
----
-
-## 3. パラメータのバリデーションルール
-
-このエンドポイントでは、**入力がおかしい場合は 400 Bad Request を返す**。
-
-### 3.1 `page`
-
-- 未指定 or 空文字 → `1` とみなす
-- 数値に変換できない → **400 Bad Request**
-- `page < 1` → `1` に正規化（エラーにしない）
-
-### 3.2 `limit`
-
-- 未指定 or 空文字 → `50` とみなす
-- 数値に変換できない → **400 Bad Request**
-- `limit < 1` → `50` に正規化（エラーにしない）
-- `limit > 200` → `200` にクランプ（エラーにしない）
-
-### 3.3 `page_from` / `page_to`
-
-- 未指定 → 無視
-- いずれかが数値に変換できない → **400 Bad Request**
-- 両方指定されていて `page_from > page_to` → **400 Bad Request**
-
-> 400 のレスポンス形式は `api_overview.md` の共通エラー仕様に従う。
-
----
-
-## 4. 検索条件の適用順序（Contract）
-
-本エンドポイントにおける検索条件は、  
-以下の順序で **AND 結合** により適用される。
-
-### 4.1 必須条件
-
-- `book_id = :book_id`
-
-Rails 的には：
-
-```rb
-scope = Note.where(book_id: book.id)
+## 1. Endpoint
+```http
+GET /api/books/:book_id/notes_search
 ```
-
-
-## 4.2 キーワード検索（任意）
-
-`q` パラメータが指定された場合、`quote` / `memo` に対してキーワード検索を適用する。
-
-### 4.2.1 クエリ文字列の正規化ルール
-
-`q` パラメータは以下の正規化を行う。
-
-1. **前後の空白を削除（trim処理）**
-   - 例: `"  愛  "` → `"愛"`
-   - 例: `"ラーメン  おすすめ"` → `"ラーメン  おすすめ"` （内部の空白は保持）
-
-2. **trim後に空文字になる場合の扱い**
-   - `q=""` または `q="   "` （空白のみ）の場合、trim後に空文字となる
-   - この場合、**`q` 未指定扱いとする**（キーワード検索フィルタを適用しない）
-   - つまり、一覧取得の挙動になる
-   - ※ 400 Bad Request は返さない（未指定扱いで統一）
-
-### 4.2.2 空白区切り AND 検索
-
-trim後の `q` に空白が含まれる場合、空白区切りでトークン化し、**AND検索**を行う。
-
-**トークン化のルール**:
-- 連続する空白は1つの区切りとして扱う
-- 例: `"ラーメン  おすすめ"` → `["ラーメン", "おすすめ"]` （2トークン）
-- 例: `"愛"` → `["愛"]` （1トークン）
-
-**検索条件の構築**:
-- 各トークンは `quote` / `memo` に対して部分一致検索（ILIKE相当、大文字小文字無視）
-- トークン同士は **AND結合**
-  - つまり、**全トークンがヒットする note のみ返す**
-
-**SQL イメージ（擬似コード）**:
-```sql
--- q="ラーメン おすすめ" の場合
-WHERE book_id = :book_id
-  AND (
-    (quote ILIKE '%ラーメン%' OR memo ILIKE '%ラーメン%')
-    AND
-    (quote ILIKE '%おすすめ%' OR memo ILIKE '%おすすめ%')
-  )
-```
-
-**具体例**:
-
-| `q` の値 | トークン化 | 検索条件 |
-|---------|-----------|---------|
-| `"愛"` | `["愛"]` | `(quote ILIKE '%愛%' OR memo ILIKE '%愛%')` |
-| `"ラーメン おすすめ"` | `["ラーメン", "おすすめ"]` | `(quote ILIKE '%ラーメン%' OR memo ILIKE '%ラーメン%') AND (quote ILIKE '%おすすめ%' OR memo ILIKE '%おすすめ%')` |
-| `"  愛  "` | `["愛"]` | `(quote ILIKE '%愛%' OR memo ILIKE '%愛%')` （trim後） |
-| `""` or `"   "` | （未指定扱い） | キーワード検索なし（一覧取得） |
-
-**注意**:
-- 1トークンの場合、従来の単純検索と同じ挙動になる
-- トークン内に空白は存在しない（split済み）
-- 大文字・小文字は区別しない（ILIKE相当）
-
-### 4.2.3 memo が NULL の場合の検索挙動
-
-`memo` が NULL の Note は、**memo 条件では一致しない**（quote 側の一致のみが評価対象）。
-
-**例**: q="愛" のとき
-- quote="愛について", memo=NULL → ヒット（quote一致）
-- quote="人生", memo=NULL → ヒットしない（quote不一致）
-
-※ memo ILIKE ... は memo=NULL の場合 true/false ではなく UNKNOWN になるため。
-
 ---
-
-## 4.3 ページ範囲フィルタ（任意）
-
-ページ番号を用いた範囲指定。  
-指定されている項目のみ適用する。
-
-- `page_from` のみ指定 → `page >= page_from`
-- `page_to` のみ指定 → `page <= page_to`
-- `page_from` と `page_to` の両方指定 → `page BETWEEN page_from AND page_to`
-
-※ `page_from` と `page_to` の両方が指定され、`page_from > page_to` の場合は  
-**400 Bad Request** とする（パラメータエラー）。
-
----
-
-## 4.4 ソート順序（Contract）
-
-検索結果の順序は常に **`created_at DESC`（新しい順）** とする。
-
-```rb
-scope = scope.order(created_at: :desc)
-
+## 2. Authentication
+このAPIは Bearer Token 認証を必要とする。
+```http
+Authorization: Bearer <token>
 ```
-
-
----
-
-## 4.5 ページング（page / limit）
-
-
-ページング処理は以下の契約に従う。
-
-page
-
-- 未指定 → 1
-- 数値でない → 400
-- page < 1 → 1 に正規化
-
-limit
-
-- 未指定 → 50
-- 数値でない → 400
-- limit < 1 → 50 に正規化
-- limit > 200 → 200 にクランプ
-
-### 4.5.2 offset の計算式
-
-```rb
-offset = (page - 1) * limit
+未認証、無効Token、期限切れToken、revoked Token の場合は `401 Unauthorized` を返す。
+```json
+{
+  "error": {
+    "code": "unauthorized",
+    "message": "Authentication required"
+  }
+}
 ```
-
-### 4.5.3 total_count の定義
-
-total_count は「検索条件をすべて適用した後の総件数」。
-
-```rb
-book_id=1 のノート 200 件
-キーワード q="愛" を適用 → 37 件
-ページ範囲 page_from=10 を適用 → 12 件
-limit=5 のとき
-  total_count = 12
-  total_pages = ceil(12 / 5) = 3
-
-```
-
-## 5. レスポンス仕様
-
 ---
-
-## 5.1 成功時（200 OK）
-
+## 3. Ownership Boundary
+このAPIでは、Controller側で以下の条件を満たすBookのみを対象にする。
+- ログイン中ユーザーが所有していること
+- `deleted_at` が `nil` であること
+実装上は、Book取得を以下の境界で行う。
+```ruby
+current_user.books.alive.find(params[:book_id])
+```
+そのため、以下の場合はすべて `404 Not Found` として扱う。
+- Bookが存在しない
+- Bookが削除済み
+- Bookが他ユーザー所有
+```json
+{
+  "error": {
+    "code": "not_found",
+    "message": "Resource not found"
+  }
+}
+```
+これは、リソースの存在有無や所有関係を外部に露出しないためである。
+---
+## 4. Request
+### Path Parameters
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `book_id` | integer | Yes | 対象BookのID |
+### Query Parameters
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `q` | string | No | — | `quote` または `memo` に対する部分一致キーワード |
+| `page_from` | integer | No | — | ページ番号の下限 |
+| `page_to` | integer | No | — | ページ番号の上限 |
+| `page` | integer | No | `1` | ページネーションのページ番号 |
+| `limit` | integer | No | `50` | 1ページあたりの件数。最大 `200` |
+---
+## 5. Query Parameter Rules
+### 5.1 `q`
+`q` が指定された場合、`quote` / `memo` に対して部分一致検索を行う。
+- `quote` または `memo` に一致するNoteを返す
+- 大文字・小文字を区別しない検索を想定する
+- スペース区切りの場合、AND検索として扱う
+- `q` が未指定または空文字相当の場合は、キーワード検索を適用しない
+例：
+| `q` | Meaning |
+|-----|---------|
+| `Rails` | `quote` または `memo` に `Rails` を含むNote |
+| `Clean Architecture` | `Clean` と `Architecture` の両方に一致するNote |
+| 空文字 | キーワード検索なし |
+---
+### 5.2 `page_from` / `page_to`
+ページ番号による範囲検索を行う。
+- `page_from` のみ指定された場合: `page >= page_from`
+- `page_to` のみ指定された場合: `page <= page_to`
+- 両方指定された場合: `page_from <= page <= page_to`
+`page_from` / `page_to` が数値として扱えない場合、または不正な範囲指定の場合は `400 Bad Request` を返す。
+---
+### 5.3 `page` / `limit`
+ページネーションに使用する。
+- `page` 未指定時は `1`
+- `limit` 未指定時は `50`
+- `limit` の最大値は `200`
+- 数値として扱えない値が指定された場合は `400 Bad Request` を返す
+---
+## 6. Sort Order
+検索結果は `created_at DESC` で返す。
+```ruby
+order(created_at: :desc)
+```
+---
+## 7. Success Response
+### 200 OK
 ```json
 {
   "notes": [
@@ -240,7 +107,7 @@ limit=5 のとき
       "page": 10,
       "quote": "人間は耐えることができるのだ。",
       "memo": "テスト用",
-      "created_at": "2025-12-05T02:52:03.377Z"
+      "created_at": "2026-06-11T04:00:14.670Z"
     }
   ],
   "meta": {
@@ -251,14 +118,92 @@ limit=5 のとき
   }
 }
 ```
-
-### 5.1.1 `meta` オブジェクト仕様
-
-検索結果に付随する `meta` の構造は以下のとおり。
-
-| key          | 型  | 説明 |
-|--------------|-----|------|
-| `total_count` | int | 条件にマッチしたノートの総件数 |
-| `page`        | int | 現在のページ番号 |
-| `limit`       | int | 1ページあたりの最大件数 |
-| `total_pages` | int | `ceil(total_count / limit)` の結果 |
+### Response Fields
+| Field | Type | Description |
+|-------|------|-------------|
+| `notes` | array | Noteオブジェクトの配列 |
+| `notes[].id` | integer | Note ID |
+| `notes[].book_id` | integer | Book ID |
+| `notes[].page` | integer | ページ番号 |
+| `notes[].quote` | string | 引用文 |
+| `notes[].memo` | string / null | メモ |
+| `notes[].created_at` | string | 作成日時 |
+| `meta.total_count` | integer | 条件に一致した総件数 |
+| `meta.page` | integer | 現在のページ番号 |
+| `meta.limit` | integer | 1ページあたりの件数 |
+| `meta.total_pages` | integer | 総ページ数 |
+---
+## 8. Empty Result
+検索条件に一致するNoteが存在しない場合も、`200 OK` を返す。
+```json
+{
+  "notes": [],
+  "meta": {
+    "total_count": 0,
+    "page": 1,
+    "limit": 10,
+    "total_pages": 0
+  }
+}
+```
+---
+## 9. Error Responses
+### 400 Bad Request
+クエリパラメータが不正な場合。
+例：
+- `page` が数値として扱えない
+- `limit` が数値として扱えない
+- `page_from` / `page_to` が数値として扱えない
+- `page_from > page_to`
+```json
+{
+  "error": {
+    "code": "bad_request",
+    "message": "Bad request"
+  }
+}
+```
+---
+### 401 Unauthorized
+認証に失敗した場合。
+```json
+{
+  "error": {
+    "code": "unauthorized",
+    "message": "Authentication required"
+  }
+}
+```
+---
+### 404 Not Found
+対象Bookが存在しない、削除済み、またはログイン中ユーザーの所有Bookではない場合。
+```json
+{
+  "error": {
+    "code": "not_found",
+    "message": "Resource not found"
+  }
+}
+```
+---
+## 10. 本番確認済み挙動
+本番環境で以下を確認済み。
+- キーワード検索
+  - `GET /api/books/:book_id/notes_search?q=Rails&page=1&limit=10`
+  - `200 OK`
+  - キーワードに一致するNoteのみ返却
+- ページ範囲検索
+  - `GET /api/books/:book_id/notes_search?page_from=10&page_to=20&page=1&limit=10`
+  - `200 OK`
+  - 指定したページ範囲に一致するNoteのみ返却
+- 該当なし検索
+  - `GET /api/books/:book_id/notes_search?q=nonexistentkeyword&page=1&limit=10`
+  - `200 OK`
+  - `notes: []`
+- 不正なクエリパラメータ
+  - `GET /api/books/:book_id/notes_search?page=abc&limit=10`
+  - `400 Bad Request`
+- 他ユーザーBookへのSearch
+  - `404 Not Found`
+  - 所有権情報を露出しない
+---


### PR DESCRIPTION
Summary

API仕様書・README・設計ドキュメントを、現在の実装状態に合わせて更新しました。

主な更新内容:

* READMEの評価導線を整理
    * Production URL
    * Health Check
    * Quick Evaluation Route
    * 詳細curl例は api_overview.md へ集約
* api_overview.md を現行API仕様に合わせて更新
    * Bearer Token認証
    * ユーザー作成 / ログイン / ログアウト
    * Books / Notes / Bulk Create / Search
    * 共通エラーレスポンス形式
    * 本番確認済みフロー
* Bulk / Search API contractを現行仕様に合わせて更新
    * 認証必須
    * 所有者境界
    * current_user.books.alive.find(...)
    * Bulk Createのall-or-nothing
    * Searchの空結果・不正パラメータ・所有権境界
* Architecture docsを更新
    * Error Handling
    * Soft Delete Policy
    * Notes Destroy Authorization
    * Invariants
    * Request spec authentication policy

Design Notes

今回の更新では、以下の設計方針がドキュメント上でも一貫するように整理しました。

* Book ID を受け取るNotes系APIでは、Controller入口で認証・所有権・alive確認を行う
* Serviceには確認済みBookを渡し、処理本体に責務を集中させる
* エラー処理は ApplicationController の rescue_from に集約する
* API全体で { error: { code, message, details? } } の形式に統一する
* 削除済みBook・他ユーザーBook・存在しないBookはいずれも 404 Not Found として扱う
* Bulk Createは全件成功 or 全件失敗のトランザクションとして扱う

Test

* Documentation only
* No application code changes